### PR TITLE
Fluid mobile font and viewport breakpoint standardization

### DIFF
--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -38,9 +38,22 @@
     margin-bottom: 0;
 }
 
+.tla-descrip {
+    font-size: 5.5vw;
+
+    @media (min-width: 700px) {
+        font-size: 1.5em;
+    }
+}
+
 .page-title{
-    font-size: 3em;
+    // font-size: 3em;
+    font-size: 12vw;
     margin-bottom: 0;
+
+    @media (min-width: 700px) {
+        font-size: 3em;
+    }
 }
 
 .divider{

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -41,7 +41,7 @@
 .tla-descrip {
     font-size: 5.5vw;
 
-    @media (min-width: 700px) {
+    @media (min-width: $desktop-width) {
         font-size: 1.5em;
     }
 }
@@ -51,7 +51,7 @@
     font-size: 12vw;
     margin-bottom: 0;
 
-    @media (min-width: 700px) {
+    @media (min-width: $desktop-width) {
         font-size: 3em;
     }
 }
@@ -72,7 +72,7 @@
 .col{
     max-width: 100%;
     height: 100%;
-    @media (min-width: 700px) {
+    @media (min-width: $desktop-width) {
         display: flex;
         flex-direction: column;
         flex-basis: 100%;
@@ -90,7 +90,7 @@
         margin-top: .5em;
     }
 
-    @media (min-width: 700px) {
+    @media (min-width: $desktop-width) {
         flex-direction: row;
 
         a {
@@ -108,7 +108,7 @@
         margin-top: .5em;
     }
 
-    @media (min-width: 700px) {
+    @media (min-width: $desktop-width) {
         flex-direction: row;
         justify-content: center;
 

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -47,7 +47,6 @@
 }
 
 .page-title{
-    // font-size: 3em;
     font-size: 12vw;
     margin-bottom: 0;
 

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -169,7 +169,7 @@ tr:nth-child(even) {
     display: grid;
     grid-template-columns: 33% 33% 33%;
 
-    @media (max-width: 700px) {
+    @media (max-width: $desktop-width) {
         height: 100%;
         max-width: 100%;
         display: grid;

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -8,7 +8,11 @@
     .footer-title{
         margin-top: 0;
         margin-bottom: 0;
-        font-size: 3em;
+        font-size: 12vw;
+
+        @media (min-width: 700px) {
+            font-size: 3em;
+        }
     }
 
     .footer-link{
@@ -19,6 +23,10 @@
         }
     }
     .footer-contact-list{
-        font-size: 1.5em;
+        font-size: 5.5vw;
+
+        @media (min-width: 700px) {
+            font-size: 1.5em;
+        }
     }
 }

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -10,7 +10,7 @@
         margin-bottom: 0;
         font-size: 12vw;
 
-        @media (min-width: 700px) {
+        @media (min-width: $desktop-width) {
             font-size: 3em;
         }
     }
@@ -25,7 +25,7 @@
     .footer-contact-list{
         font-size: 5.5vw;
 
-        @media (min-width: 700px) {
+        @media (min-width: $desktop-width) {
             font-size: 1.5em;
         }
     }

--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -200,7 +200,7 @@
 		color: $teachla-green !important;
 	}
 
-	@media (max-width: 700px) {
+	@media (max-width: $desktop-width) {
 		#desktop-nav { display: none; }
 		#mobile-nav { display: inline-block; }
 	}

--- a/_sass/_team.scss
+++ b/_sass/_team.scss
@@ -7,8 +7,4 @@
     padding-bottom: 1.2em;
     padding-left: 1.2em;
     padding-right: 1.2em;
-  
-    @media (max-width: $desktop-width) {
-        margin-right: auto;
-    }
 }

--- a/_sass/_team.scss
+++ b/_sass/_team.scss
@@ -1,5 +1,6 @@
 .profile-img {
     width: 30%;
+    min-width: 30%;
     display: flex;
     justify-content: flex-start;
     border-radius: 30%;

--- a/_sass/_team.scss
+++ b/_sass/_team.scss
@@ -4,7 +4,7 @@
     height: auto;
     margin-left: auto;
     border-radius: 4px;
-    @media (max-width: 700px) {
+    @media (max-width: $desktop-width) {
         margin-right: auto;
     }
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -2,34 +2,6 @@ $acm-cobalt: #3B59ED;
 $acm-black: #262938;
 $acm-tint: #ACBAFA;
 
-//  $hack-purple: #C960FF;
-//  $hack-black: #262938;
-//  $hack-tint: #DB99FD;
-
-//  $w-teal: #1BC3A9;
-//  $w-black: #233431;
-//  $w-tint: #80D3C6;
-
-//  $icpc-tangerine: #FF6B6B;
-//  $icpc-black: #3A2B2B;
-//  $icpc-tint: #EEAEAE;
-
-//  $ai-arctic: #1EBDF4;
-//  $ai-black: #233339;
-//  $ai-tint: #94D8F0;
-
-//  $studio-raspberry: #ED3266;
-//  $studio-black: #39272B;
-//  $studio-tint: #F09FB0;
-
-//  $cyber-amber: #FFBA44;
-//  $cyber-black: #3A3327;
-//  $cyber-tint: #EDCD98;
-
-//  $design-orange: #FE823C;
-//  $design-black: #372B25;
-//  $design-tint: #FFBC96;
-
 $teachla-green: #A1D900;
 $teachla-black: #2C3022;
 $teachla-tint: #C6DC85;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -40,3 +40,5 @@ $font-body: 'Chivo', sans-serif;
 
 $font-primary-color: #333333;
 $font-secondary-color: #777777;
+
+$desktop-width: 850px;

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ title: "Home"
     </div>
     <div class="col">
         <h1 class="title page-title">ACM <span class="text-teachla">Teach LA</span></h1>
-        <h2 class="title">making coding 
+        <h2 class="title tla-descrip">making coding 
             <span class="vertical-slide">
                 <span>accessible.</span>
                 <span>fun.</span>


### PR DESCRIPTION
Basically fixes the issue where headers wrap and the text "making coding ..." is too large and pushes against the size of its container.

All it does is makes the text depend on viewport width when viewing in mobile and reverts to original sizing when viewing on a desktop.

Happy Thanksgiving yall!

Edit: Also changes all viewport breakpoints to a sass variable set at 850px