### PR TITLE
Uses flexbox to make footer sticky

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
   <body>
 
     {%- include header.html -%}
-    <div class="container">
+    <div class="container container-fill">
       {{ content }}
     </div>
 

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -7,10 +7,13 @@
     margin: 0;
     padding: 0;
     padding-top: 70px;
-    min-height: 100%;
+    // min-height: 100%;
+    min-height: calc(100vh - 70px);
     min-width: 100%;
     font-family: $font-body;
     color: $font-primary-color;
+    display: flex;
+    flex-direction: column;
 }
 
 .word-splitter {
@@ -22,7 +25,8 @@
 .container {
     padding: 1em;
     margin: auto;
-    max-width: 1000px;
+    max-width: 1000px; // enforces a not-too-wide text viewport
+    flex: 1 0 auto; // makes container grow into screen
 }
 
 .list-unstyled {

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -26,6 +26,9 @@
     padding: 1em;
     margin: auto;
     max-width: 1000px; // enforces a not-too-wide text viewport
+}
+
+.container-fill{
     flex: 1 0 auto; // makes container grow into screen
 }
 

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -1,9 +1,9 @@
 .footer{
     width: 100%;
-	min-height: 120px;
     background-color: $teachla-green;
     color: white;
     font-family: $font-display;
+    flex-shrink: 0; // this is to make it a sticky footer
 
     .footer-title{
         margin-top: 0;


### PR DESCRIPTION
This should be a light PR - implements a [sticky footer](https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/), so that when the page doesn't have enough content, the footer still goes to the bottom of the screen. Will come in handy as we add more (short) pages.

To test: look at the instructor page `/instructor-faq`.