### PR TITLE
Adjusting Team Page (element ids, layout spacing and tweaking, content & cleanup)

### DIFF
--- a/_data/alums.yml
+++ b/_data/alums.yml
@@ -1,41 +1,3 @@
-2017-2018:
-  apanse: 
-    name: Apurva Panse 
-    title: President and Outreach Director
-    year: 2018
-  rwen:
-    name: Richard Wen 
-    title: Curriculum Director
-    year: 2019
-  kbabu:
-    name: Krishna Babu
-    title: Logistics Director
-    year: 2018
-2018-2019:
-  jstucky:
-    name: John Stucky
-    title: President
-    year: 2019
-  rwen:
-    name: Richard Wen
-    title: President and Outreach Director
-    year: 2019
-  mgrieve:
-    name: Michael Grieve
-    title: Curriculum Director, Lead Instructor
-    year: 2019
-  ftech:
-    name: Furn Techalertumpai
-    title: Logistics Director
-    year: 2020
-  cborden:
-    name: Connor Borden
-    title: Dev Team Director
-    year: 2019
-  blee:
-    name: Bonnie Lee
-    title: Expansion Director
-    year: 2021
 2019-2020:
   cindudhara:
     name: Christina Indudhara
@@ -69,3 +31,41 @@
     name: Sharvani Jha
     title: NHHS Lead
     year: 2021
+2018-2019:
+  jstucky:
+    name: John Stucky
+    title: President
+    year: 2019
+  rwen:
+    name: Richard Wen
+    title: President and Outreach Director
+    year: 2019
+  mgrieve:
+    name: Michael Grieve
+    title: Curriculum Director, Lead Instructor
+    year: 2019
+  ftech:
+    name: Furn Techalertumpai
+    title: Logistics Director
+    year: 2020
+  cborden:
+    name: Connor Borden
+    title: Dev Team Director
+    year: 2019
+  blee:
+    name: Bonnie Lee
+    title: Expansion Director
+    year: 2021
+2017-2018:
+  apanse: 
+    name: Apurva Panse 
+    title: President and Outreach Director
+    year: 2018
+  rwen:
+    name: Richard Wen 
+    title: Curriculum Director
+    year: 2019
+  kbabu:
+    name: Krishna Babu
+    title: Logistics Director
+    year: 2018

--- a/_data/board.yml
+++ b/_data/board.yml
@@ -1,31 +1,46 @@
 mwang:
-  name: "Matt Wang"
+  name: "Matthew Wang"
   title: "President"
   github: malsf21 
+  email: matt@matthewwang.me
   img: mwang.jpg
 asubramonian:
   name: "Arjun Subramonian"
   title: "Logistics Director"
+  secondary: "AI/ML Lead"
   github: ArjunSubramonian
   img: asubramonian.jpg
-blee:
-  name: "Bonnie Lee"
-  title: "Advisor"
-  github: bonniebonnielee
-  img: blee.jpg
-mhmimy:
-  name: "Malak Hmimy"
-  title: "Sepulveda Team Lead"
-  github: malakh21
-  img: mhmimy.jpg
-scho:
-  name: "Shane Cho"
+sschoenmeyer:
+  name: "Sophie Schoenmeyer"
+  title: "Logistics Director"
+  img: sschoenmeyer.jpg
+krash:
+  name: "Leo Krashanoff"
+  title: "Dev Team Director"
+  github: krashanoff
+  img: krash.jpg
+cuy:
+  name: "Chloe Uy"
+  title: "Outreach Director"
+  secondary: "Emerson Lead"
+  img: cuy.png
+nkumar:
+  name: "Nikhil Kumar"
   title: "Curriculum Director"
-  github: shanefcho
+  secondary: "Python Lead"
+  img: nkumar.jpg
+# scho:
+#   name: "Shane Cho"
+#   title: "Curriculum Director"
 pragathi:
   name: "Pragathi Venkatesh"
-  title: "Brockton Team Lead"
+  title: "Brockton School Lead"
+  secondary: "Scratch Lead"
   img: pragathi.jpg
+mhmimy:
+  name: "Malak Hmimy"
+  title: "Sepulveda School Lead"
+  img: mhmimy.jpg
 knamuduri:
   name: "Keertana Namuduri"
   title: "Special Events Director"
@@ -34,18 +49,6 @@ nlu:
   name: "Nina Lu"
   title: "Special Events Director"
   img: nlu.jpg
-sschoenmeyer:
-  name: "Sophie Schoenmeyer"
-  title: "Logistics Director"
-  img: sschoenmeyer.jpg
-nkumar:
-  name: "Nikhil Kumar"
-  title: "Curriculum Director"
-  img: nkumar.jpg
-cuy:
-  name: "Chloe Uy"
-  title: "Outreach Director"
-  img: cuy.png
 regina:
   name: "Regina Wang"
   title: "Special Events Director"
@@ -54,8 +57,11 @@ regina:
 kwang:
   name: Kaitlyn Wang
   title: Special Events Director
-krash:
-  name: "Leo Krashanoff"
-  title: "Dev Team Director"
-  github: krashanoff
-  img: krash.jpg
+sjha:
+  name: "Sharvani Jha"
+  title: "Moonshots Advisor"
+  img: sharvani.png
+blee:
+  name: "Bonnie Lee"
+  title: "Advisor"
+  img: blee.jpg

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,57 +1,16 @@
-sjha:
-  name: "Sharvani Jha"
-  title: "ACM Moonshots & AI Advisor"
-  img: sharvani.png
 jliu:
   name: "Jamie Liu"
-  title: "Dev Team Member"
+  title: "Lead Developer"
   github: jamieliu386
   img: jliu.jpg
-asane:
-  name: "Aseem Sane"
-  title: "Dev Team Member"
-  github: aseem191
-  img: asane.jpg
-awang:
-  name: "Alyssa Wang"
-  title: "Dev Team Member"
-  github: alyssamw
-  img: awang.jpg
 wobrien:
   name: "Will O'Brien"
-  title: "Dev Team Member"
+  title: "Lead Developer"
   github: willob99
   img: willob.jpg
-mattf:
-  name: "Matt Fan"
-  title: "Dev Team Member"
-  github: fan-matt
-  img: mattf.png
-rl:
-  name: "Rachel Li"
-  title: "Dev Team Member"
-  github: rachelli99
-mkang:
-  name: "Miles Kang"
-  title: "Dev Team Member"
-  img: miles.jpg
-michellz:
-  name: "Michelle Zhuang"
-  title: "Dev Team Member"
-  img: michellz.jpg
-anguyen:
-  name: "Alvin Nguyen"
-  title: "Dev Team Member"
-  github: AlvinoNguyen
-  img: anguyen.jpg
-tomokif:
-  name: "Tomoki T. Fukazawa"
-  title: "Dev Team Member"
-  github: tfukaza
-  img: tomokif.jpg
 nvan:
   name: "Nhi Van"
-  title: "Dev Team Member"
+  title: "Lead Developer"
   github: vohndernet
   img: nvan.jpg
 aghodsian:
@@ -66,23 +25,60 @@ ckapler:
   name: "Chase Kapler"
   title: "Instructor"
   img: ckapler.jpg
+asane:
+  name: "Aseem Sane"
+  title: "Developer"
+  github: aseem191
+  img: asane.jpg
+awang:
+  name: "Alyssa Wang"
+  title: "Developer"
+  github: alyssamw
+  img: awang.jpg
+mattf:
+  name: "Matt Fan"
+  title: "Developer"
+  github: fan-matt
+  img: mattf.png
+rl:
+  name: "Rachel Li"
+  title: "Developer"
+  github: rachelli99
+mkang:
+  name: "Miles Kang"
+  title: "Developer"
+  img: miles.jpg
+michellz:
+  name: "Michelle Zhuang"
+  title: "Developer"
+  img: michellz.jpg
+anguyen:
+  name: "Alvin Nguyen"
+  title: "Developer"
+  github: AlvinoNguyen
+  img: anguyen.jpg
+tomokif:
+  name: "Tomoki T. Fukazawa"
+  title: "Developer"
+  github: tfukaza
+  img: tomokif.jpg
 hco:
   name: "Hanna Co"
-  title: "Dev Team Member"
+  title: "Developer"
   github: hannaco
   img: hco.jpg
 jtsai:
   name: "Janice Tsai"
-  title: "Dev Team Member"
+  title: "Developer"
   github: janicetsai1
   img: jtsai.jpg
 tpoon:
   name: "Timothy Poon"
-  title: "Dev Team Member"
+  title: "Developer"
   github: lumisphere902
   img: tpoon.jpg
 ezhong:
   name: "Evan Zhong"
-  title: "Dev Team Member"
+  title: "Developer"
   github: evazhog
   img: ezhong.jpg

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -51,6 +51,10 @@
     margin-bottom: 0;
 }
 
+.font-display{
+    font-family: $font-display;
+}
+
 .tla-descrip {
     font-size: 5.5vw;
 
@@ -187,24 +191,6 @@
         &:nth-child(even) {
             background-color: $teachla-tint;
         }
-    }
-}
-
-.member-name{
-    font-size: 1.4em;
-}
-
-.team-content {
-    height: 100%;
-    max-width: 100%;
-    display: grid;
-    grid-template-columns: 33% 33% 33%;
-
-    @media (max-width: $desktop-width) {
-        height: 100%;
-        max-width: 100%;
-        display: grid;
-        grid-template-columns: 100%;
     }
 }
 

--- a/_sass/_team.scss
+++ b/_sass/_team.scss
@@ -1,27 +1,52 @@
 .profile-img-container{
-    max-width: 512px;
-    width: 30%;
     padding-top: 1.2em;
     padding-bottom: 1.2em;
     padding-right: 1.2em;
+    width: 6em;
     @media (max-width: $desktop-width) {
-        padding-left: 1.2em;
+        width: 40vw;
     }
 }
 
 .profile-img {
     display: block;
-    width: 6.1em;
-    height: 6.1em;
+    width: 100%;
+    height: auto;
     border-radius: 4px;
+}
+
+.team-member-grid {
+    height: 100%;
+    max-width: 100%;
+    display: grid;
+    grid-template-columns: 33% 33% 33%;
+
     @media (max-width: $desktop-width) {
-        width: 100%;
-        height: auto;
+        grid-template-columns: 100%;
     }
 }
 
-.profile-link {
-    color: inherit;
-    text-decoration: none;
-    outline: none;
+.board-member-grid{
+    grid-template-columns: 50% 50%;
+    font-size: 1.2em;
+    @media (max-width: $desktop-width) {
+        grid-template-columns: 100%;
+    }
+}
+
+.team-member-content{
+    @media (max-width: $desktop-width) {
+        > h3 {
+            font-size: 1.5em;
+        }
+
+        > .team-member-position {
+            font-size: 1.25em;
+        }
+    }
+    @media (min-width: $desktop-width) {
+        > p {
+            margin: 0;
+        }
+    }
 }

--- a/team.html
+++ b/team.html
@@ -3,67 +3,91 @@ layout: default
 title: "Team"
 permalink: "/team"
 ---
-<h1 class="title page-title">Board</h1>
+<h1 class="title page-title">Team</h1>
 <p>
-    Our board consists of UCLA students who have dedicated themselves to empowering students through computer science.
+    Here are all of the awesome people that make Teach LA happen! We're UCLA students who have dedicated themselves to empowering students through computer science.
+</p>
+<h2 class="title">Board</h2>
+
+<p>
+    Our directors, school leads, and curriculum leads. Feel free to reach out to any of our board for more information about what we do!
 </p>
 
-<div class="team-content">
+<div class="team-member-grid board-member-grid">
     {% for member in site.data.board %}
-    <div class="grid-row">
-
-        {% if member[1].github %}
-        <a class="profile-link" href="https://github.com/{{ member[1].github }}">
-        {% endif %}
-
-        <div class="profile-img-container">
-            {% if member[1].img %}
-                <img class="profile-img" src="{{site.baseurl}}/img/team/{{member[1].img}}" alt="picture of {{member[1].name}}"/>
-            {% else %}
-                <img class="profile-img" src="https://api.adorable.io/avatars/512/{{member[0]}}.png" alt="temporary picture"/>
-            {% endif %}
+    <div class="grid-row" id="{{member[0]}}">
+        <div class="grid-col">
+            <div class="profile-img-container">
+                {% if member[1].img %}
+                    <img class="profile-img" src="{{site.baseurl}}/img/team/{{member[1].img}}" alt="picture of {{member[1].name}}"/>
+                {% else %}
+                    <img class="profile-img" src="https://api.adorable.io/avatars/512/{{member[0]}}.png" alt="temporary picture"/>
+                {% endif %}
+            </div>
         </div>
 
-        {% if member[1].github %}
-        </a>
-        {% endif %}
-
         <div class="grid-col">
-            <h4 class="title no-margin member-name">{{ member[1].name }}</h4>
-            <p class="no-margin">{{member[1].title}}</p>
+            <div class="team-member-content">
+                <h3 class="no-margin title">{{ member[1].name }}</h3>
+                <p class="team-member-position">
+                    {{member[1].title}}
+                    {% if member[1].secondary %}
+                        &amp; {{member[1].secondary}}
+                    {% endif %}
+                </p>
+                <ul class="list-unstyled">
+                    {% if member[1].email %}
+                    <li>
+                        <a class="tla-link" href="mailto:{{member[1].email}}"><span class="fa fa-envelope"></span> {{member[1].email}}</a>
+                    </li>
+                    {% endif %}
+                    {% if member[1].github %}
+                        <li>
+                            <a class="tla-link" href="https://github.com/{{member[1].github}}"><span class="fab fa-github"></span> {{member[1].github}}</a>
+                        </li>
+                    {% endif %}
+                </ul>
+            </div>
         </div>
     </div>
     {% endfor %}
 </div>
 
-<h1 class="title page-title">Team</h1>
+<h2 class="title">Instructors and Developers</h2>
 <p>
-    Our team of instructors and developers teach in person at schools all throughout the LAU school district while developing new, interactive ways of making an education in computer science possible for everyone.
+    Our team of instructors and developers teach in person at schools all throughout the Los Angeles Unified School District while developing new, interactive ways of making an education in computer science possible for everyone.
 </p>
 
-<div class="team-content">
+<div class="team-member-grid">
     {% for member in site.data.team %}
-    <div class="grid-row">
-
-        {% if member[1].github %}
-        <a class="profile-link" href="https://github.com/{{ member[1].github }}">
-        {% endif %}
-
-        <div class="profile-img-container">
-            {% if member[1].img %}
-                <img class="profile-img" src="{{site.baseurl}}/img/team/{{member[1].img}}" alt="picture of {{member[1].name}}"/>
-            {% else %}
-                <img class="profile-img" src="https://api.adorable.io/avatars/512/{{member[0]}}.png" alt="temporary picture"/>
-            {% endif %}
+    <div class="grid-row" id="{{member[0]}}">
+        <div class="grid-col">
+            <div class="profile-img-container">
+                {% if member[1].img %}
+                    <img class="profile-img" src="{{site.baseurl}}/img/team/{{member[1].img}}" alt="picture of {{member[1].name}}"/>
+                {% else %}
+                    <img class="profile-img" src="https://api.adorable.io/avatars/512/{{member[0]}}.png" alt="temporary picture"/>
+                {% endif %}
+            </div>
         </div>
 
-        {% if member[1].github %}
-        </a>
-        {% endif %}
-
         <div class="grid-col">
-            <h4 class="title no-margin member-name">{{ member[1].name }}</h4>
-            <p class="no-margin">{{member[1].title}}</p>
+            <div class="team-member-content">
+                <h3 class="no-margin title">{{ member[1].name }}</h3>
+                <p class="team-member-position">{{member[1].title}}</p>
+                <ul class="list-unstyled">
+                    {% if member[1].email %}
+                    <li>
+                        <a class="tla-link" href="mailto:{{member[1].email}}"><span class="fa fa-envelope"></span> {{member[1].email}}</a>
+                    </li>
+                    {% endif %}
+                    {% if member[1].github %}
+                        <li>
+                            <a class="tla-link" href="https://github.com/{{member[1].github}}"><span class="fab fa-github"></span> {{member[1].github}}</a>
+                        </li>
+                    {% endif %}
+                </ul>
+            </div>
         </div>
     </div>
     {% endfor %}
@@ -71,7 +95,7 @@ permalink: "/team"
 
 <h2 class="title">Previous Boards</h2>
 <p>
-    Teach LA has been successful thanks to many dedicated instructors, curriculum developers, and project developers.
+    <a class="tla-link" href="https://en.wikipedia.org/wiki/Rome_wasn%27t_built_in_a_day" target="_blank" rel="noopener noreferrer">Rome wasn't built in a day</a>, and neither was Teach LA! Many thanks to our previous boards for steering our organization in the right direction.
 </p>
 {% for year in site.data.alums %}
 <h3 class="title">{{ year[0] }} Board</h3>
@@ -82,9 +106,9 @@ permalink: "/team"
 </ul>
 {% endfor %}
 
-<h2 class="title">Awesome Seniors</h2>
+<h2 class="title">Awesome Alumni!</h2>
 <p>
-    Teach LA honors its seniors who have stayed with the organization through graduation.
+    Teach LA honors its alumni who have stayed with the organization through graduation.
 </p>
 <ul>
 {% for member in site.data.seniors %}


### PR DESCRIPTION
Hey there! 

I know I've got a lot of draft PRs, but I keep on going down a chain of "oh, to do this, I'll need that first". Before I implemented our Classes page, I wanted a way to list our lead instructors and link to their profiles + contact information. This PR is that, plus a few more contributions. In particular:

* adds an optional `secondary` field to each member, which can list a secondary position (such as `Python Lead`); this is inserted into the rendered card; added a few sample roles
* adds an optional `email` field to each member, which can render their email with a link; added an email for me (this should only be for public-facing roles)
* adjusts optional `github` field to be explicitly rendered with text, rather than a link on the photo (which is an accessibility issue)
* adds a unique `id` to the row element of each member, which allows us to link to them via hash
* re-orders the previous boards to be last-to-first
* significant CSS cleanup (removing several duplicate properties, magical numbers, and code motion)
* better adjusts spacing on mobile (this fixes a strange bug on live with some flexbox shenanigans)
* minor copy adjustments