### PR TITLE
Basic Scaffolding for AI/ML Collection

### DIFF
--- a/_aiml/01-what-is-ai.md
+++ b/_aiml/01-what-is-ai.md
@@ -1,0 +1,9 @@
+---
+title: "What is AI?"
+layout: aiml-lesson
+num: 1
+next_text: What is Deep Learning?
+slides_link: "https://docs.google.com/presentation/d/1yzc0K7pztHydPVXGULlYszm-J_OnqRxkjr5PlQ4RHDc/"
+---
+
+You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?

--- a/_aiml/01-what-is-ai.md
+++ b/_aiml/01-what-is-ai.md
@@ -6,4 +6,4 @@ next_text: What is Deep Learning?
 slides_link: "https://docs.google.com/presentation/d/1yzc0K7pztHydPVXGULlYszm-J_OnqRxkjr5PlQ4RHDc/"
 ---
 
-You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?
+You've probably heard of Artificial Intelligence in the news. But what *exactly is AI*?

--- a/_aiml/01-what-is-ai.md
+++ b/_aiml/01-what-is-ai.md
@@ -6,4 +6,4 @@ next_text: What is Deep Learning?
 slides_link: "https://docs.google.com/presentation/d/1yzc0K7pztHydPVXGULlYszm-J_OnqRxkjr5PlQ4RHDc/"
 ---
 
-You've probably heard of Artificial Intelligence in the news. But what *exactly is AI*?
+You've probably heard of Artificial Intelligence in the news. But what *exactly* is AI?

--- a/_aiml/02-what-is-dl.md
+++ b/_aiml/02-what-is-dl.md
@@ -6,4 +6,4 @@ next_text: Supervised Learning
 slides_link: "https://docs.google.com/presentation/d/1eDwEFXscmPcLhBuYd9ar0gSkjtiyFay55q4IpwgbA5w/"
 ---
 
-Deep learning has revolutionized AI! But, what *exactly is it* and how is it different from AI and machine learning?
+Deep learning has revolutionized AI! But, what *exactly* is it, and how is it different from AI and machine learning?

--- a/_aiml/02-what-is-dl.md
+++ b/_aiml/02-what-is-dl.md
@@ -1,0 +1,9 @@
+---
+title: "What is DL?"
+layout: aiml-lesson
+num: 2
+next_text: Supervised Learning
+slides_link: "https://docs.google.com/presentation/d/1eDwEFXscmPcLhBuYd9ar0gSkjtiyFay55q4IpwgbA5w/"
+---
+
+You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?

--- a/_aiml/02-what-is-dl.md
+++ b/_aiml/02-what-is-dl.md
@@ -1,9 +1,9 @@
 ---
-title: "What is DL?"
+title: "What is Deep Learning?"
 layout: aiml-lesson
 num: 2
 next_text: Supervised Learning
 slides_link: "https://docs.google.com/presentation/d/1eDwEFXscmPcLhBuYd9ar0gSkjtiyFay55q4IpwgbA5w/"
 ---
 
-You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?
+Deep learning has revolutionized AI! But, what *exactly is it* and how is it different from AI and machine learning?

--- a/_aiml/03-supervised-learning.md
+++ b/_aiml/03-supervised-learning.md
@@ -6,4 +6,4 @@ next_text: Intro to Linear Regression
 slides_link: "https://docs.google.com/presentation/d/12SeUiu74ZH4AOfIeWMMl8w02xylcTPjMLhwsaxMgYlM/"
 ---
 
-You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?
+As mad as LeBron at JR Smith for costing the Cavaliers Game 1 Of the 2018 NBA Finals? Channel that anger into learning about supervised learning, training, and testing!

--- a/_aiml/03-supervised-learning.md
+++ b/_aiml/03-supervised-learning.md
@@ -1,0 +1,9 @@
+---
+title: "Supervised Learning"
+layout: aiml-lesson
+num: 3
+next_text: Intro to Linear Regression
+slides_link: "https://docs.google.com/presentation/d/12SeUiu74ZH4AOfIeWMMl8w02xylcTPjMLhwsaxMgYlM/"
+---
+
+You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?

--- a/_aiml/04a-linear-regression.md
+++ b/_aiml/04a-linear-regression.md
@@ -7,4 +7,4 @@ slides_link: "https://docs.google.com/presentation/d/16b5fIM80mlOgvMK4_ly5ESvD9a
 colab_link: "https://colab.research.google.com/drive/1nDYDtYytcDvz6q3_mneFHIbVigYUiGIT"
 ---
 
-You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?
+Lines are powerful! (You may take a look at the Colab now, but it will make more sense by Lesson 4d.)

--- a/_aiml/04a-linear-regression.md
+++ b/_aiml/04a-linear-regression.md
@@ -1,0 +1,10 @@
+---
+title: "Introduction to Linear Regression"
+layout: aiml-lesson
+num: 4a
+prev_slug: 03-supervised-learning
+slides_link: "https://docs.google.com/presentation/d/16b5fIM80mlOgvMK4_ly5ESvD9a01t1rolWXHVtvi0YQ/"
+colab_link: "https://colab.research.google.com/drive/1nDYDtYytcDvz6q3_mneFHIbVigYUiGIT"
+---
+
+You've probably heard of Artificial Intelligence and Machine Learning in the news. But what *exactly is AI & ML*?

--- a/_aiml/04b-ml-math.md
+++ b/_aiml/04b-ml-math.md
@@ -1,0 +1,10 @@
+---
+title: "Machine Learning Math"
+layout: aiml-lesson
+num: 4b
+prev_slug: 04a-linear-regression
+slides_link: "https://docs.google.com/presentation/d/1bqA8_lfYeiMi_qLj5U1IetR7NXodFY09dYsOiwVyxaA/"
+colab_link: "https://colab.research.google.com/drive/16ExCL7Ih8i-aJ9FkV_o4JxVQchSmzMHw"
+---
+
+KK Slider teaching you how to multiply matrices?! Heck yeah!

--- a/_aiml/04c-gradient-descent.md
+++ b/_aiml/04c-gradient-descent.md
@@ -1,0 +1,10 @@
+---
+title: "Gradient Descent"
+layout: aiml-lesson
+num: 4c
+prev_slug: 04b-ml-math
+slides_link: "https://docs.google.com/presentation/d/171qmNd9pk2Bmd8NEUVTYSd23Us8icOcEaAG0eIwjtyA/"
+colab_link: "https://colab.research.google.com/drive/1g7lrW1h5n5JQcnXFebu_wnZJFJTZeDpU"
+---
+
+You heard right! Machine learning models train by taking hikes down steep mountains. After all, the decision trees are quite beautiful.

--- a/_aiml/04d-linear-regression-tf.md
+++ b/_aiml/04d-linear-regression-tf.md
@@ -1,0 +1,10 @@
+---
+title: "Linear Regression w/ TensorFlow"
+layout: aiml-lesson
+num: 4d
+prev_slug: 04c-gradient-descent
+slides_link: "https://docs.google.com/presentation/d/10gUdfZdEmBCgZMBo1Sj7ZYoQgBE4cAx5XPd3j7LQXPE/"
+colab_link: "https://colab.research.google.com/drive/1nDYDtYytcDvz6q3_mneFHIbVigYUiGIT"
+---
+
+Lines are even more powerful when you know TensorFlow!

--- a/_aiml/05-logistic-regression.md
+++ b/_aiml/05-logistic-regression.md
@@ -1,0 +1,9 @@
+---
+title: "Logistic Regression"
+layout: aiml-lesson
+num: 5
+prev_slug: 04d-linear-regression-tf
+slides_link: "https://docs.google.com/presentation/d/10Jhvqlr5pM5orlLxpS4Y4z1QNkOB8nq6zz1xmk_spn0/"
+---
+
+Let's train a model that can classify an image as being of either a dog or cat!

--- a/_aiml/06-bayes-theorem.md
+++ b/_aiml/06-bayes-theorem.md
@@ -1,0 +1,9 @@
+---
+title: "Bayes’ Theorem"
+layout: aiml-lesson
+num: 6
+prev_slug: 05-logistic-regression
+slides_link: "https://docs.google.com/presentation/d/1MplPOPCFn6-CCcGPMvOempQrXA_fR20ZV4N_5hniPBs/"
+---
+
+Hey, baes, let's leverage Bayes' Theorem to build a spam filter!

--- a/_aiml/07-bce-loss.md
+++ b/_aiml/07-bce-loss.md
@@ -1,0 +1,9 @@
+---
+title: "Binary Cross-Entropy Loss"
+layout: aiml-lesson
+num: 7
+prev_slug: 06-bayes-theorem
+slides_link: "https://docs.google.com/presentation/d/1Vqsy1wmZqD-1tP1dbleiJRG0irw1Or_TZ5rEMOcNnxk/"
+---
+
+Using probability as a shovel, we'll dig a little deeper into binary cross-entropy loss (you know, the thing that we optimize to train logistic regression models).

--- a/_aiml/08-fc-neural-networks.md
+++ b/_aiml/08-fc-neural-networks.md
@@ -1,0 +1,9 @@
+---
+title: "Fully-Connected Neural Networks"
+layout: aiml-lesson
+num: 8
+prev_slug: 07-bce-loss
+slides_link: "https://docs.google.com/presentation/d/1GpQkI9bcFbWteC0yxY-zg7Tt_fP-2CyG8EAWbfcL7ws/"
+---
+
+Ooh, let's demystify neural networks! (And, no, they do not work like the brain does.)

--- a/_aiml/09-optimization-regularization.md
+++ b/_aiml/09-optimization-regularization.md
@@ -1,0 +1,10 @@
+---
+title: "Optimization & Regularization"
+layout: aiml-lesson
+num: 9
+prev_slug: 08-fc-neural-networks
+slides_link: "https://docs.google.com/presentation/d/12NXfWnHBUz20b4QpF_br_sJtAtjxue7Wb2M8f9Q4YBQ/"
+colab_link: "https://colab.research.google.com/drive/1XSBk5EywDSUutcRh4HR4tV2_ggH7M9H5"
+---
+
+Gradient descent is throwing a party, and we're all invited! Get ready to meet its family and friends.

--- a/_aiml/10-CNN.md
+++ b/_aiml/10-CNN.md
@@ -1,0 +1,10 @@
+---
+title: "Convolutional Neural Networks"
+layout: aiml-lesson
+num: 10
+prev_slug: 09-optimization-regularization
+slides_link: "https://docs.google.com/presentation/d/1ujlAQlwT21QAAkZeCAML0ejEQzEkT034rHfjraO5VRQ/"
+colab_link: "https://colab.research.google.com/drive/1veXBzYK4XWbDleBJL8SBfBAGht4-WN3R"
+---
+
+Images, filters, and networks, oh my! We'll break down convolutional neural networks without any convolutions. (slides are in progress)

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,9 @@ dev_team_interest: https://forms.gle/Yu49uA374S6caAmu9
 
 # collections
 collections:
+  aiml:
+    permalink: /classes/ml/:name
+    output: true
   reports:
     output: true
     permalink: /reports/:name

--- a/_data/board.yml
+++ b/_data/board.yml
@@ -9,6 +9,7 @@ asubramonian:
   name: "Arjun Subramonian"
   title: "Logistics Director"
   secondary: "AI/ML Lead"
+  email: arjun.subramonian@gmail.com
   github: ArjunSubramonian
   img: asubramonian.jpg
 sschoenmeyer:

--- a/_data/classes.yml
+++ b/_data/classes.yml
@@ -39,22 +39,21 @@
     hash: mwang
 
 - name: "Intro to Artificial Intelligence and Machine Learning"
-  blurb: "This course aims to delve deep into one of the most popular topics of computer science, starting by giving students a strong foundation in mathematical concepts, and then applying them to create their own neural networks."
+  blurb: "This course aims to delve deep into one of the most popular topics of computer science, starting by giving students a strong foundation in mathematical concepts, and then applying them to train their own neural networks."
   img: "undraw/ai.svg"
   tags: 
     - 20+ one-hour classes
-    - precalculus and some coding preferred
+    - precalculus and some coding experience recommended
   goals:
     - "understand what AI and ML are, and their differences"
-    - "learn about Deep Learning and its applications"
-    - "differentiate between supervised and unsupervised learning"
-    - "use Python and related libraries in Juptyer Notebook"
-    - "plot and explore data with matplotlib in Jupyter Notebook"
-    - "learn and apply linear regression to best-fit datasets"
-    - "understand the concept behind gradient descent"
-    - "learn and apply logistic regression to classify datasets"
-    - "understand conceptually Bayes Theorem, Cross-Entropy, and distributions"
-    - "walk through and devise a neural network"
+    - "learn about deep learning and its applications"
+    - "differentiate between classification and regression"
+    - "use Python and related libraries in Google Colab to manipulate data"
+    - "learn and apply linear regression to real-world datasets"
+    - "understand the intuition behind gradient descent"
+    - "learn and apply logistic regression to real-world datasets"
+    - "understand probability, Bayes' Theorem, and binary cross-entropy loss at a conceptual level"
+    - "walk through the building blocks of a neural network"
     - "understand the challenges behind optimization and the applications of regularization"
     - "conceptually grasp and implement convolutional neural networks"
     - "explore the ethics behind applications of AI and ML"

--- a/_data/classes.yml
+++ b/_data/classes.yml
@@ -57,6 +57,7 @@
     - "understand the challenges behind optimization and the applications of regularization"
     - "conceptually grasp and implement convolutional neural networks"
     - "explore the ethics behind applications of AI and ML"
+  path: ml
   lead:
     name: "Arjun"
     hash: asubramonian

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer">
-    <div class="container">
+    <div class="container container-restricted">
         <div class="footer-row">
             <div>
                 <h2 class="footer-title">ACM Teach LA</h2>

--- a/_layouts/aiml-lesson.html
+++ b/_layouts/aiml-lesson.html
@@ -1,0 +1,45 @@
+---
+layout: default
+---
+
+<div class="ai-content-container">
+    <div>
+        <div class="ai-content-card">
+            <h1 class="title text-2x no-margin">{{page.title}}</h1>
+            <p>
+                {{content}}
+            </p>
+            <hr class="divider-ai" />
+            <ul class="list-unstyled text-15x">
+                {% if page.slides_link %}
+                    <li>
+                        <a class="ai-link" href="{{page.slides_link}}" target="_blank" rel="noopener noreferrer">
+                            <span class="fa fa-chalkboard-teacher"></span> Link to slides
+                        </a>
+                    </li>
+                {% endif %}
+                {% if page.colab_link %}
+                    <li>
+                        <a class="ai-link" href="{{page.colab_link}}" target="_blank" rel="noopener noreferrer">
+                            <span class="fa fa-book"></span> Link to Google Colab
+                        </a>
+                    </li>
+                {% endif %}
+            </ul>
+            <hr class="divider-ai" />
+            <div>
+                {% if page.next %}
+                    <a class="button button-ai button-block" href="{{page.next.slug}}">
+                        <span class="fa fa-arrow-right"></span> next lesson: {{page.next_text}}
+                    </a>
+                {% endif %}
+                <a class="button button-ai button-block" href="{{site.baseurl}}/classes/ml/">
+                    <span class="fa fa-arrow-left"></span> back to lessons
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="iframe-container">
+        <iframe class="ai-slide-iframe" src="{{page.slides_link}}embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+    </div>
+</div>

--- a/_layouts/aiml-lesson.html
+++ b/_layouts/aiml-lesson.html
@@ -44,3 +44,7 @@ fw: true
         <iframe class="ai-slide-iframe" src="{{page.slides_link}}embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
     </div>
 </div>
+
+<script>
+    logTopSecretMessage("Note from the devs: there's a CORS error, we know. This is upstream with Google, unfortunately nothing we can do :(");
+</script>

--- a/_layouts/aiml-lesson.html
+++ b/_layouts/aiml-lesson.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+fw: true
 ---
 
 <div class="ai-content-container">

--- a/_layouts/aiml-lesson.html
+++ b/_layouts/aiml-lesson.html
@@ -22,7 +22,7 @@ fw: true
                 {% if page.colab_link %}
                     <li>
                         <a class="ai-link" href="{{page.colab_link}}" target="_blank" rel="noopener noreferrer">
-                            <span class="fa fa-book"></span> Link to Google Colab
+                            <span class="fa fa-code"></span> Link to Code (Google Colab)
                         </a>
                     </li>
                 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,9 @@
   <body>
 
     {%- include header.html -%}
-    <div class="container container-fill {% if page.fw != true %}container-restricted{% endif %}">
+    <div class="container container-fill {% if layout.fw %}{% else %}container-restricted{% endif %}">
       {{ content }}
+      {{page.fw}}
     </div>
 
     {%- include footer.html -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
   <body>
 
     {%- include header.html -%}
-    <div class="container container-fill">
+    <div class="container container-fill {% if page.fw != true %}container-restricted{% endif %}">
       {{ content }}
     </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,12 +6,6 @@
   <body>
 
     {%- include header.html -%}
-    <div class="container container-fill {% if layout.fw %}{% else %}container-restricted{% endif %}">
-      {{ content }}
-      {{page.fw}}
-    </div>
-
-    {%- include footer.html -%}
     <script>
       function logTopSecretMessage(message){
         console.log(
@@ -24,6 +18,12 @@
       logTopSecretMessage("Don't worry, our site isn't collecting any data about you, or anything, really. Pinky promise.");
       logTopSecretMessage("You look like somebody who likes web programming and hacking. Why not join our dev team? Check out https://teachla.uclaacm.com/dev");
     </script>
+    <div class="container container-fill {% if layout.fw %}{% else %}container-restricted{% endif %}">
+      {{ content }}
+      {{page.fw}}
+    </div>
+
+    {%- include footer.html -%}
   </body>
 
 </html>

--- a/_sass/_aiml.scss
+++ b/_sass/_aiml.scss
@@ -19,7 +19,7 @@
 
 .ai-lesson-card {
     padding: 0.5em;
-    margin-top: 2em;
+    margin-top: 1em;
     border: 2px solid $ai-blue;
     border-radius: 10px;
     width: 90%;
@@ -27,6 +27,10 @@
     margin-right: auto;
     display: flex;
     flex-direction: column;
+}
+
+.ai-lesson-card-content {
+    flex: 1 0 auto;
 }
 
 .ai-content-container{
@@ -50,6 +54,9 @@
     display: block;
     width: 100%;
     height: calc(100% * 1469/2559);
+    @media (max-width: $desktop-width) {
+        height: 100%;
+    }
 }
 
 .iframe-container {

--- a/_sass/_aiml.scss
+++ b/_sass/_aiml.scss
@@ -1,0 +1,59 @@
+.ai-link {
+    @include tla-link($ai-blue);
+}
+
+.divider-ai {
+    border-top: 1px solid $ai-blue;
+}
+
+.ai-lessons-grid {
+    height: 100%;
+    max-width: 100%;
+    display: grid;
+    grid-template-columns: 33% 33% 33%;
+    @media (max-width: $desktop-width) {
+        grid-template-columns: 100%;
+    }
+    margin-bottom: 2em;
+}
+
+.ai-lesson-card {
+    padding: 0.5em;
+    margin-top: 2em;
+    border: 2px solid $ai-blue;
+    border-radius: 10px;
+    width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.ai-content-container{
+    display: grid;
+    grid-template-columns: 30% 70%;
+    min-height: 100vh;
+    @media (max-width: $desktop-width) {
+        grid-template-columns: 100%;
+        min-height: 70vh;
+    }
+}
+
+.ai-content-card {
+    margin-top: 3em;
+    padding: 1em;
+    border-radius: 10px;
+    border: 1px solid $ai-blue;
+}
+
+.ai-slide-iframe{
+    display: block;
+    width: 100%;
+    height: calc(100% * 1469/2559);
+}
+
+.iframe-container {
+    padding: 3em;
+    width: calc(100% - 6em);
+    position: relative;
+}

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -34,12 +34,15 @@ ul > li {
 
 .container {
     padding: 0 1em;
-    margin: auto;
-    max-width: 1000px; // enforces a not-too-wide text viewport
 }
 
 .container-fill{
     flex: 1 0 auto; // makes container grow into screen
+}
+
+.container-restricted {
+    margin: auto;
+    max-width: 1000px; // enforces a not-too-wide text viewport
 }
 
 .list-unstyled {
@@ -66,6 +69,10 @@ ul > li {
     font-style: italic;
 }
 
+.text-normal{
+    font-weight: normal;
+}
+
 .title{
     font-family: $font-display;
     margin-bottom: 0;
@@ -73,6 +80,10 @@ ul > li {
 
 .text-2x{
     font-size: 2em;
+}
+
+.text-15x{
+    font-size: 1.5em;
 }
 
 .font-display{

--- a/_sass/_button.scss
+++ b/_sass/_button.scss
@@ -17,7 +17,7 @@
         background-color: $acm-black;
         border: 2px solid $acm-black;
     }
-    >.fa {
+    >.fa, .fab, .fas {
         margin-right: 0.5em;
     }
 }
@@ -35,6 +35,27 @@
         background-color: white;
         border: 2px solid $acm-black;
     }
+}
+
+.button.button-ai{
+    color: $ai-blue;
+    border: 2px solid $ai-blue;
+    &:hover {
+        color: white;
+        background: $ai-blue;
+        cursor: pointer;
+    }
+    
+    &:active {
+        color: $ai-blue;
+        background-color: white;
+        border: 2px solid $ai-blue;
+    }
+}
+
+.button-block{
+    display: block;
+    margin-bottom: 0.5em;
 }
 
 .button-container {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -6,6 +6,8 @@ $teachla-green: #A1D900;
 $teachla-black: #2C3022;
 $teachla-tint: #C6DC85;
 
+$ai-blue: #5ABBEF;
+
 $font-display: 'Poppins', 'Helvetica Neue', 'Helvetica', sans-serif;
 $font-header: 'Palanquin Dark', sans-serif;
 $font-body: 'Chivo', sans-serif;

--- a/classes/aiml.html
+++ b/classes/aiml.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Introduction to AI & ML"
-permalink: /classes/ml/
+permalink: /classes/ml
 ---
 
 <h1 class="title page-title">Introduction to AI & ML</h1>
@@ -15,9 +15,11 @@ permalink: /classes/ml/
 
 <p>
     We present a year-long, modern machine learning class led by UCLA students! Students will discover and explore the computational and mathematical tools behind artificial intelligence and machine learning! In a single year, they will advance from understanding simple AI models that predict weather to analyzing the complex AI systems that power self-driving cars.
-    <br><br>
+</p>
+<p>
     Throughout the year, students will have numerous opportunities to learn and code with Python. Python is one of the most popular programming languages in use today, with wide-ranging applications in data processing, web development, and machine learning. Last year, our students used Python to train AI models that predict stock market prices, guess the popularity of a song on Spotify, and detect handwritten digits.
-    <br><br>
+</p>
+<p>
     Learning machine learning does not occur in a vacuum! We encourage our students to think critically about the applications and ethics of AI. In the past, we’ve brainstormed which types of AI are best-suited to tackle facial recognition and estimate house prices. Furthermore, we’ve held in-depth discussions on the ethics of AI-powered self-driving cars and what it actually means for AI to be racist.
 </p>
 
@@ -28,10 +30,12 @@ permalink: /classes/ml/
 <div class="ai-lessons-grid">
     {% for lesson in site.aiml %}
         <div class="ai-lesson-card">
-            <h3 class="title no-margin"><span class="text-normal">#{{lesson.num}}</span> 
-                <a class="ai-link" href="{{lesson.url}}">{{lesson.title}}</a>
-            </h3>
-            {{lesson.excerpt}}
+            <div class="ai-lesson-card-content">
+                <h3 class="title no-margin"><span class="text-normal">#{{lesson.num}}</span> 
+                    <a class="ai-link" href="{{lesson.url}}">{{lesson.title}}</a>
+                </h3>
+                {{lesson.excerpt}}
+            </div>
             <div class="button-container">
                 {% if lesson.slides_link %}
                     <a class="button button-ai" href="{{lesson.slides_link}}" target="_blank" rel="noopener noreferrer">

--- a/classes/aiml.html
+++ b/classes/aiml.html
@@ -1,0 +1,46 @@
+---
+layout: default
+title: "Introduction to AI & ML"
+permalink: /classes/ml/
+fw: true
+---
+
+<h1 class="title page-title">Introduction to AI & ML</h1>
+<p class="title text-2x no-margin">Class & Curriculum Outline</p>
+<hr class="divider-ai" />
+<p>Learn machine learning, with us! A joint collaboration with <a class="ai-link" href="https://uclaacmai.github.io" target="_blank" rel="noopener noreferrer">ACM AI Outreach</a>.</p>
+
+<h2 class="title">
+    Brief Overview
+</h2>
+
+<p>
+    ...
+</p>
+
+<h2 class="title" id="lessons">
+    Lessons
+</h2>
+
+<div class="ai-lessons-grid">
+    {% for lesson in site.aiml %}
+        <div class="ai-lesson-card">
+            <h3 class="title no-margin"><span class="text-normal">#{{lesson.num}}</span> 
+                <a class="ai-link" href="{{lesson.url}}">{{lesson.title}}</a>
+            </h3>
+            {{lesson.excerpt}}
+            <div class="button-container">
+                {% if lesson.slides_link %}
+                    <a class="button button-ai" href="{{lesson.slides_link}}" target="_blank" rel="noopener noreferrer">
+                        <span class="fa fa-chalkboard-teacher"></span> slides
+                    </a>
+                {% endif %}
+                {% if lesson.colab_link %}
+                    <a class="button button-ai" href="{{lesson.colab_link}}" target="_blank" rel="noopener noreferrer">
+                        <span class="fa fa-book"></span> colab
+                    </a>
+                {% endif %}
+            </div>
+        </div>
+    {% endfor %}
+</div>

--- a/classes/aiml.html
+++ b/classes/aiml.html
@@ -14,7 +14,11 @@ permalink: /classes/ml/
 </h2>
 
 <p>
-    ...
+    We present a year-long, modern machine learning class led by UCLA students! Students will discover and explore the computational and mathematical tools behind artificial intelligence and machine learning! In a single year, they will advance from understanding simple AI models that predict weather to analyzing the complex AI systems that power self-driving cars.
+    <br><br>
+    Throughout the year, students will have numerous opportunities to learn and code with Python. Python is one of the most popular programming languages in use today, with wide-ranging applications in data processing, web development, and machine learning. Last year, our students used Python to train AI models that predict stock market prices, guess the popularity of a song on Spotify, and detect handwritten digits.
+    <br><br>
+    Learning machine learning does not occur in a vacuum! We encourage our students to think critically about the applications and ethics of AI. In the past, we’ve brainstormed which types of AI are best-suited to tackle facial recognition and estimate house prices. Furthermore, we’ve held in-depth discussions on the ethics of AI-powered self-driving cars and what it actually means for AI to be racist.
 </p>
 
 <h2 class="title" id="lessons">

--- a/classes/aiml.html
+++ b/classes/aiml.html
@@ -44,7 +44,7 @@ permalink: /classes/ml
                 {% endif %}
                 {% if lesson.colab_link %}
                     <a class="button button-ai" href="{{lesson.colab_link}}" target="_blank" rel="noopener noreferrer">
-                        <span class="fa fa-book"></span> colab
+                        <span class="fa fa-code"></span> code
                     </a>
                 {% endif %}
             </div>

--- a/classes/aiml.html
+++ b/classes/aiml.html
@@ -2,7 +2,6 @@
 layout: default
 title: "Introduction to AI & ML"
 permalink: /classes/ml/
-fw: true
 ---
 
 <h1 class="title page-title">Introduction to AI & ML</h1>

--- a/css/main.scss
+++ b/css/main.scss
@@ -4,8 +4,9 @@
 // Derives all of the code from the _sass folder, and just pieces it together!
  
 @import "variables";
-@import "animations";
 @import "basic";
+@import "aiml";
+@import "animations";
 @import "button";
 @import "classes";
 @import "dev";

--- a/resources.html
+++ b/resources.html
@@ -83,95 +83,17 @@ permalink: "/resources"
 <h3 class="title">Artificial Intelligence and Machine Learning at North Hollywood High School</h3>
 <ul>
         <li>
-                Lesson 1 : What is AI?
-                (
                 <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://drive.google.com/open?id=1yzc0K7pztHydPVXGULlYszm-J_OnqRxkjr5PlQ4RHDc">
-                        Slides
+                        href="/classes/ml/">
+                        All Lessons
                 </a>
-                )
         </li>
         <li>
-                Lesson 2: What is ML?
-                (
                 <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://drive.google.com/open?id=1eDwEFXscmPcLhBuYd9ar0gSkjtiyFay55q4IpwgbA5w">
-                        Slides
+                        href="https://drive.google.com/file/d/1b-NUdhieq6yPRvsEWn_MxaLUZ8sIw0vk/">
+                        Plotting Data
                 </a>
-                )
         </li>
-        <li>
-                Lesson 3: Introduction to Plotting Data
-                (
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://drive.google.com/open?id=12M3ApbtPJPZsLugfH-OObV1tvkMzWJtO">
-                        Jupyter Notebook
-                </a>
-                )
-        </li>
-        <li>
-                Lesson 4 + 5: Linear Regression
-                (
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://docs.google.com/presentation/d/16b5fIM80mlOgvMK4_ly5ESvD9a01t1rolWXHVtvi0YQ/">
-                        Slides
-                </a>
-                +
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://drive.google.com/open?id=1n8bK5dcoLHauctBDyy_1I018tlb619Nr">
-                        Jupyter Notebook
-                </a>
-                )
-        </li>
-        <li>
-                Lesson 6: Logistic Regression
-                (
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://docs.google.com/presentation/d/10Jhvqlr5pM5orlLxpS4Y4z1QNkOB8nq6zz1xmk_spn0/">
-                        Slides
-                </a>
-                +
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://docs.google.com/document/d/1KydvuiJfRXEPLxfhh3sW0s9cFhO33D3AKTRNLrRh3O4/">
-                        Homework
-                </a>
-                )
-        </li>
-        <li>
-                Lesson 7: Bayes' Theorem and Normal Distribution
-                (
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://docs.google.com/presentation/d/1MplPOPCFn6-CCcGPMvOempQrXA_fR20ZV4N_5hniPBs">
-                        Slides
-                </a>
-                +
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://docs.google.com/document/d/1YeXe2v026-sRqgZ0eLt8YaQ5HvBZAuFG-k9COsD6hmc/">
-                        Homework
-                </a>
-                )
-        </li>
-        <li>
-                Lesson 8: Intro to Neural Networks
-                (
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://docs.google.com/presentation/d/11F4KTtDHgqLMJP0HPtXw6v_3mvWlqu7Fi18XlugxUHM/">
-                        Slides
-                </a>
-                )
-        </li>
-        <li>
-                Lesson 9: AI Ethics & Self Driving Cars
-                (
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="https://docs.google.com/presentation/d/1ZpOxNl2DjZaobwf2CusuHbwUcpTFMZlPN1v2hXqehZY/">
-                        Slides
-                </a>
-                )
-        </li>
-</ul>
-<h3 class="title">Misc.</h3>
-<ul>
         <li>
                 <a class="tla-link" target="_blank" rel="noopener noreferrer"
                         href="https://colab.research.google.com/drive/13YIFjKEWZolW1nZhPl72Es3nTRb6QixP">

--- a/resources.html
+++ b/resources.html
@@ -83,8 +83,8 @@ permalink: "/resources"
 <h3 class="title">Artificial Intelligence and Machine Learning at North Hollywood High School</h3>
 <ul>
         <li>
-                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                        href="/classes/ml/">
+                <a class="tla-link"
+                        href="{{site.baseurl}}/classes/ml/">
                         All Lessons
                 </a>
         </li>


### PR DESCRIPTION
This PR targets #57, laying the groundwork for an MVP of the AI/ML collection. It does a few things:

* creates a collection `_aiml`, designed to hold a set of markdown documents for individual AI/ML lessons
* creates a layout `aiml-lesson`, which is a slide-centric page for each AI/ML lesson; creates `_aiml.scss` file with `$ai-blue` themed items
* implements `classes/aiml` page to act as a hub for the AI/ML class
* thanks to @ArjunSubramonian for adding all the new content from ACM AI Outreach's passover! also includes minor data changes
* adds override `fw` to Jekyll layouts to disable the `max-width` container in `default` layout; uses this disable in `aiml` for maximum screen real estate
* moves position of `logTopSecretMessage` in `default`, uses top-level function to log CORS issue in `aiml-lesson.html`
* removes old AI/ML lessons from resources page
* extra minor text utilities

One problem: 
* Google Slides' `iframe` embed link has a CORS issue. Seems like this is an upstream problem, not much we can do here.

Preview: https://deploy-preview-65--unruffled-perlman-fe51d2.netlify.app/classes/ml/