### PR TITLE
Switch to FA5 Free (Kit)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="{{site.baseurl}}/img/logo-teachla.png" />
   <link rel="stylesheet" href="{{ "/css/main.css" | relative_url }}" />
   <link href="https://fonts.googleapis.com/css?family=Chivo:300,400|Palanquin+Dark:600|Poppins:400,600,700" rel="stylesheet" />
-  <script src="https://kit.fontawesome.com/a549ff53c3.js" defer async></script>
+  <script src="https://kit.fontawesome.com/a549ff53c3.js" crossorigin="anonymous" defer async></script>
   {% seo title=false %}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}

--- a/classes/classes.html
+++ b/classes/classes.html
@@ -62,7 +62,7 @@ permalink: "/classes"
                     {% endif %}
                     {% if class.outline %}
                     <a class="button button-dark" href="{{class.outline}}">
-                        <span class="fa fa-books"></span>
+                        <span class="fa fa-file-alt"></span>
                         Curriculum Outline
                     </a>
                     {% endif %}


### PR DESCRIPTION
Looks like I can update the kit attached to my FA5 account to switch it to Free Only. Did that, and gave it a quick look: only made two quick changes:

* adds `crossorigin="anonymous"` to our kit request
* switches `fa-books` to `fa-file-alt` for "curriculum outline" button on the classes page (`fa-books` is pro-only)

Would like a second pair of eyes to make sure that I didn't miss any icons. In addition, for all of our open PRs that create new page elements, we'll need to *reaudit* them to make sure that they aren't adding any pro icons.

Closes #66.

Preview: https://deploy-preview-67--unruffled-perlman-fe51d2.netlify.app/