### PR TITLE
Move AI/ML "further resources" to class page

### DIFF
--- a/_data/curriculum_resources.yml
+++ b/_data/curriculum_resources.yml
@@ -1,39 +1,41 @@
-further:
-  - aiml:
-    title: "Artificial Intelligence and Machine Learning"
-    description: "These are our favorite AI/ML resources! We've ordered them by how relevant and useful we think they are, but they're all awesome."
-    items: 
-      - acmai:
-        title: "ACM AI Resources"
-        items: 
-          - name: "ACM AI Blog"
-            link: "http://uclaacmai.github.io/"
-      - introdl:
-        title: "Intro to Deep Learning"
-        items:
-          - name: "Coursera: Deep Learning Specialization"
-            link: "https://www.coursera.org/specializations/deep-learning"
-          - name: "The Deep Learning Textbook"
-            link: "http://www.deeplearningbook.org/"
-          - name: "3Blue1Brown: Neural Networks"
-            link: "https://www.youtube.com/playlist?list=PLZHQObOWTQDNU6R1_67000Dx_ZCJB-3pi"
-          - name: "Udacity: Intro to Deep Learning with TensorFlow"
-            link: "https://www.udacity.com/course/intro-to-tensorflow-for-deep-learning--ud187"
-      - tfpytorch:
-        title: "Tensorflow and Pytorch"
-        items:
-          - name: "UC Berkeley: CS294 Tensorflow Tutorial"
-            link: "https://youtu.be/xZKj7Z1CwHc"
-          - name: "UC Berkeley: CS285 (Deep Reinforcement Learning) Resources"
-            link: "http://rail.eecs.berkeley.edu/deeprlcourse/resources/"
-          - name: "Pytorch: Getting Started with Pytorch"
-            link: "https://pytorch.org/tutorials/"
-      - introml:
-        title: "Intro to Machine Learning"
-        items:
-          - name: "Coursera: Introduction to Machine Learning"
-            link: "https://www.coursera.org/learn/machine-learning"
-          - name: "Hal Daumé III: A Course in Machine Learning"
-            link: "http://ciml.info/"
-          - name: "Google: Machine Learning Crash Course"
-            link: "https://developers.google.com/machine-learning/crash-course/"
+aiml:
+  - acmai:
+    title: "ACM AI Resources"
+    items:
+      - name: "You Belong in AI! Podcast"
+        link: "https://anchor.fm/ucla-acm-ai"
+      - name: "ACM AI Blog"
+        link: "http://uclaacmai.github.io/"
+      - name: "Plotting Data Notebook"
+        link: "https://drive.google.com/file/d/1b-NUdhieq6yPRvsEWn_MxaLUZ8sIw0vk/"
+      - name: "MNIST Dataset with Keras Notebook (Archer School Event)"
+        link: "https://colab.research.google.com/drive/13YIFjKEWZolW1nZhPl72Es3nTRb6QixP"
+  - introdl:
+    title: "Intro to Deep Learning"
+    items:
+      - name: "Coursera: Deep Learning Specialization"
+        link: "https://www.coursera.org/specializations/deep-learning"
+      - name: "The Deep Learning Textbook"
+        link: "http://www.deeplearningbook.org/"
+      - name: "3Blue1Brown: Neural Networks"
+        link: "https://www.youtube.com/playlist?list=PLZHQObOWTQDNU6R1_67000Dx_ZCJB-3pi"
+      - name: "Udacity: Intro to Deep Learning with TensorFlow"
+        link: "https://www.udacity.com/course/intro-to-tensorflow-for-deep-learning--ud187"
+  - tfpytorch:
+    title: "Tensorflow and Pytorch"
+    items:
+      - name: "UC Berkeley: CS294 Tensorflow Tutorial"
+        link: "https://youtu.be/xZKj7Z1CwHc"
+      - name: "UC Berkeley: CS285 (Deep Reinforcement Learning) Resources"
+        link: "http://rail.eecs.berkeley.edu/deeprlcourse/resources/"
+      - name: "Pytorch: Getting Started with Pytorch"
+        link: "https://pytorch.org/tutorials/"
+  - introml:
+    title: "Intro to Machine Learning"
+    items:
+      - name: "Coursera: Introduction to Machine Learning"
+        link: "https://www.coursera.org/learn/machine-learning"
+      - name: "Hal Daumé III: A Course in Machine Learning"
+        link: "http://ciml.info/"
+      - name: "Google: Machine Learning Crash Course"
+        link: "https://developers.google.com/machine-learning/crash-course/"

--- a/classes/aiml.html
+++ b/classes/aiml.html
@@ -31,7 +31,7 @@ permalink: /classes/ml
     {% for lesson in site.aiml %}
         <div class="ai-lesson-card">
             <div class="ai-lesson-card-content">
-                <h3 class="title no-margin"><span class="text-normal">#{{lesson.num}}</span> 
+                <h3 class="title no-margin"><span class="text-normal">#{{lesson.num}}</span>
                     <a class="ai-link" href="{{lesson.url}}">{{lesson.title}}</a>
                 </h3>
                 {{lesson.excerpt}}
@@ -51,3 +51,21 @@ permalink: /classes/ml
         </div>
     {% endfor %}
 </div>
+
+<h2 class="title">More Resources</h2>
+<p>
+    These are our favorite AI/ML resources - they're all awesome!
+</p>
+{% for subcategory in site.data.curriculum_resources.aiml %}
+        <h3 class="title">{{subcategory.title}}</h3>
+        <ul>
+                {% for item in subcategory.items %}
+                <li>
+                        <a class="ai-link" target="_blank" rel="noopener noreferrer"
+                                href="{{item.link}}">
+                                {{item.name}}
+                        </a>
+                </li>
+                {% endfor %}
+        </ul>
+{% endfor %}

--- a/resources.html
+++ b/resources.html
@@ -5,6 +5,9 @@ permalink: "/resources"
 ---
 
 <h1 class="title page-title">Resources</h1>
+<p class="title text-15x">
+        Heads up! We're moving most of the content of this page to other parts of our site, like our <a class="tla-link" href="{{site.baseurl}}/classes">new classes page</a> where you can find all of our updated and digitized curriculum/lesson plans!
+</p>
 <div class="row">
         <div class="col">
                 <h2 class="title">Editor</h2>
@@ -101,24 +104,3 @@ permalink: "/resources"
                 </a>
         </li>
 </ul>
-<h2 class="title">Further Learning</h2>
-<p>
-        Here are our team's favourite resources for learning more, organized by topic and relevant course material:
-</p>
-{% for category in site.data.curriculum_resources.further %}
-        <h3 class="title">{{category.title}}</h3>
-        <p>{{category.description}}</p>
-        {% for subcategory in category.items %}
-                <h4 class="title">{{subcategory.title}}</h4>
-                <ul>
-                        {% for item in subcategory.items %}
-                        <li>
-                                <a class="tla-link" target="_blank" rel="noopener noreferrer"
-                                        href="{{item.link}}">
-                                        {{item.name}}
-                                </a>
-                        </li>
-                        {% endfor %}
-                </ul>
-        {% endfor %}
-{% endfor %}


### PR DESCRIPTION
This PR just shuffles the AI/ML further resources entry to the AI/ML class page, in preparation for axing the resources page. It also adds a notice that content is being moved.

Something to think about: should we have a single `curriculum_resources.yml` file, or an `aiml_resources.yml` file? Latter might be better as we add more metadata about our classes.