### PR TITLE
adjust ruby head to 2.7.1 until ruby3 support becomes widespread

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, head]
+        ruby: [2.6, 2.7.1]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Very small PR, but want to test if the action succeeds. Needs to be back-merged into all of our open branches.