### PR TITLE
Removes resources page from nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,6 @@
         <li><a href="{{site.baseurl}}/about">About</a></li>
         <li><a href="{{site.baseurl}}/classes">Classes</a></li>
         <li><a href="{{site.baseurl}}/dev">Dev</a></li>
-        <li><a href="{{site.baseurl}}/resources">Resources</a></li>
         <li><a href="{{site.baseurl}}/team">Team</a></li>
         <li class="nav-button"><a href="{{site.editor_link}}">Editor</a></li>
       </ul>
@@ -30,7 +29,6 @@
           <li><a href="{{site.baseurl}}/about">About</a></li>
           <li><a href="{{site.baseurl}}/classes">Classes</a></li>
           <li><a href="{{site.baseurl}}/dev">Dev</a></li>
-          <li><a href="{{site.baseurl}}/resources">Resources</a></li>
           <li><a href="{{site.baseurl}}/team">Team</a></li>
           <li class="nav-button"><a href="{{site.editor_link}}">Editor</a></li>
         </ul>


### PR DESCRIPTION
As title mentions, removes the Resources page from the navbar, as we look to soft-deprecate the page (in favour of classes, etc.).﻿

(a quarter of #60)