### PR TITLE
Updating the About Us page

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,77 +14,63 @@ permalink: "/about"
 
 <h2 class="title" id="teacher-join">How Do I Join As A Teacher?</h2>
 <p>
-    Due to the novel coronavirus and subsequent virtual instruction, Teach LA has also shifted to online instruction and meetings. If you're interested in joining us, send us an email at <a class="tla-link" href="mailto:{{site.email}}">{{site.email}}</a>!
+    Great question! Why not check out our <a class="tla-link" href="{{site.baseurl}}/join">join us page?</a>
 </p>
-<!-- <p>
-    The best way to find out more is to join our mailing list!
-</p>
-<a class="button" href="https://tinyurl.com/teachmail"><span class="fa fa-fw fa-envelope"></span> Join Our Mailing List</a>
 <p>
-    We meet weekly on Tuesdays at 7:30-8:30 PM in the ACM Clubhouse (Boelter 2763). Feel free to pop by and say hi!
-</p> -->
-<!-- <p>
     If you have other questions, you can also send us an email at <a class="tla-link" href="mailto:{{site.email}}">{{site.email}}</a>!
-</p> -->
+</p>
 <h2 class="title" id="school-join">We're a School/Organization. Can We Work Together?</h2>
 <p>
     Of course! Currently, we're looking to partner with schools to run quarter/year-long curriculums, as well as running one-off instructional and networking events. If you're interested, please send an email to <a class="tla-link" href="mailto:{{site.email}}">{{site.email}}</a>.
 </p>
 
-<h2 class="title">Spring Quarter Schools and Schedules</h2>
+<h2 class="title" id="schedule">Fall Quarter Schools and Schedules</h2>
 <p>
-    Due to physical shutdowns of UCLA and the LAUSD, Teach LA is transitioning to online instruction and content development. More updates coming soon!
-    <!--
+    Due to the COVID-19 epidemic and UCLA/LAUSD policies, all of our classes are delivered online via Zoom. All times are in PST.
+
     <table class="schedule-table">
         <tr>
             <th> Schools </th>
-            <th> Classes </th>
+            <th> Class </th>
             <th> Schedule (including travel)</th>
         </tr>
         <tr>
-            <td> Brockton Elementary School </td>
-            <td> Scratch, "CS Unplugged" </td>
-            <td> Tuesdays: 2pm - 4pm </td>
+            <td> Emerson Middle School </td>
+            <td> Intro to Python </td>
+            <td> Fridays at 10:15 - 11:20 </td>
         </tr>
         <tr>
             <td> North Hollywood High School </td>
-            <td> AI/ML </td>
-            <td> Alternating Wednesday/<span class="word-splitter"> </span>Thursday: 11am - 1pm </td>
+            <td> <a class="tla-link" href="{{site.baseurl}}/classes/mobile">Web & Mobile App Development</a> </td>
+            <td> Thursdays at 10:10 - 11:25</td>
+        </tr>
+        <tr>
+            <td> BEAM (Crescent Heights, Melrose Elementary) </td>
+            <td> Scratch </td>
+            <td> TBD </td>
+        </tr>
+        <tr>
+            <td> North Hollywood High School </td>
+            <td> <a class="tla-link" href="{{site.baseurl}}/classes/ml">AI/ML</a> </td>
+            <td> Wednesdays at 1:05 - 2:15 </td>
         </tr>
         <tr>
             <td> Sepulveda Middle School </td>
-            <td> Python </td>
-            <td> Thursdays: 12:15 - 2:15 </td>
+            <td> Intro to Python </td>
+            <td> Asynchronous </td>
         </tr>
         <tr>
-            <td> Emerson Middle School </td>
-            <td> Python </td>
-            <td> Thursday, 9:30-11:00 AM (starting Jan 30, 2020) </td>
-        </tr>
-        <tr>
-            <td> UCLA Community School </td>
-            <td> Web Development </td>
-            <td> TBD </td>
-        </tr>
-        <tr>
-            <td> Mark Twain Middle School </td>
             <td> Speaker Series </td>
-            <td> TBD </td>
+            <td> Varied </td>
+            <td> N/A </td>
         </tr>
     </table>
-    -->
+
 </p>
 
-<h2 class="title">Why Teach LA?</h2>
-<p>
-    As of 2018, <a class="tla-link" href="https://code.org/files/2018_state_of_cs.pdf" target="_blank" rel="noopener noreferrer">only 22 out of 50 states</a> have K-12 computer science standards, and only <a class="tla-link" href="https://code.org/files/2018_state_of_cs.pdf" target="_blank" rel="noopener noreferrer">35% of public high schools in America</a> teach computer science. Specifically, students from minority backgrounds receive the least exposure to computer science, especially as school districts serving minority communities often lack STEM funding.
-</p>
-<p>
-    ACM Teach LA aims to fill this gap by providing schools and students with in-school and extracurricular support. Our flagship program consists of quarter to year-long structured classes on various computer science topics (basic programming, web development, machine learning, data science, computer graphics), backed by robust and structured curriculums and student tutors with academic and industry experience. We've also developed an open-source online code IDE, with the goal of supporting students' computer science learning regardless of their access to a certain type of computer. We also perform outreach, either through events (e.g. Day of Code) or by visitng schools and talking to students.
-</p>
 <h2 class="title">How Does Teach LA Work?</h2>
 <p>
-    Classes are taught once to twice a week, typically sized between 15 and 25 students, and are lead by UCLA undergraduate students with academic, personal or industry experience in computer science. Undergrads meet once a week with our Curriculum Director before each class to prepare for weekly lessons.
+    Classes are taught weekly, typically sized between 15 and 25 students, and are lead by UCLA undergraduate students with academic, personal or industry experience in computer science. Undergrads meet once a week with our Curriculum Director before each class to prepare for weekly lessons.
 </p>
 <p>
     If you are an undergrad not specifically interested in teaching but still want to contribute to Teach LA’s mission, we have a dev team in which undergrads maintain and expand Teach LA’s website. Dev team meets weekly on a separate schedule that varies.
@@ -94,11 +80,20 @@ permalink: "/about"
 </p>
 <h2 class="title">What Do Students Learn?</h2>
 <p>
-    Depending on the group of students and their coding backgrounds, we shape the class to maximize their learning. Topics that students have learned in the past include programming fundamentals (in Python or Scratch) and intro to web development (in HTML/CSS). We’re looking to expand our set of topics to the following but not limited to machine learning, data science, and computer graphics.
+    Depending on the group of students and their coding backgrounds, we shape the class to maximize their learning. Topics that students have learned in the past include programming fundamentals (in Python or Scratch) and intro to web development (in HTML/CSS), as well as complex topics like machine learning and mobile app development. We’re looking to expand our set of topics: data science, game development, digital art, you name it - if you're interested, get in touch!
 </p>
 <p>
-    You can find out more on our <a class="tla-link" href="{{site.baseurl}}/resources">resources page</a>.
+    You can find out more on our <a class="tla-link" href="{{site.baseurl}}/classes">classes</a> and <a class="tla-link" href="{{site.baseurl}}/resources">resources</a> pages.
 </p>
+
+<h2 class="title">Why Teach LA?</h2>
+<p>
+    As of 2018, <a class="tla-link" href="https://code.org/files/2018_state_of_cs.pdf" target="_blank" rel="noopener noreferrer">only 22 out of 50 states</a> have K-12 computer science standards, and only <a class="tla-link" href="https://code.org/files/2018_state_of_cs.pdf" target="_blank" rel="noopener noreferrer">35% of public high schools in America</a> teach computer science. Specifically, students from minority backgrounds receive the least exposure to computer science, especially as school districts serving minority communities often lack STEM funding.
+</p>
+<p>
+    ACM Teach LA aims to fill this gap by providing schools and students with in-school and extracurricular support. Our flagship program consists of quarter to year-long structured classes on various computer science topics (basic programming, web development, machine learning, data science, computer graphics), backed by robust and structured curriculums and student tutors with academic and industry experience. We've also developed an open-source online code IDE, with the goal of supporting students' computer science learning regardless of their access to a certain type of computer. We also perform outreach, either through events (e.g. Day of Code) or by visitng schools and talking to students.
+</p>
+
 <h2 class="title">About ACM</h2>
 <p>
     <a class="tla-link" href="https://www.uclaacm.com" target="_blank" rel="noopener noreferrer">ACM</a> is the largest computer science student organization at UCLA. It is split into eight committees (of which ACM Teach LA is one), each serving a different topic and mission. ACM regularly holds events for the UCLA community with the goal of giving students more opportunities to explore different aspects of computer science. UCLA students are encouraged to attend as many of the events as they'd like (they're free, beginner-friendly, and have free food). Organizations looking to work with ACM @ UCLA should contact ACM at <a class="tla-link" href="mailto:acm@ucla.edu">acm@ucla.edu</a>.


### PR DESCRIPTION
As much as I want to get rid of this page eventually (see #60), we didn't get around to reworking enough of the website to accomplish that _just yet_. So, in anticipation of fall quarter, I updated some of the content for the page! The most important changes are adding our fall schedule and linking to our join us page, and I also made some minor copy changes. Still, want to get rid of this page eventually.

Preview: https://deploy-preview-93--acm-teach-la-website.netlify.app/about