### PR TITLE
Blog related posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -66,18 +66,15 @@ layout: default
         {% include blog-author-card.html name=author_name role=author_role img=author_img url=author_url %}
     {% endfor %}
 
-    <!--Idea: piggyback off of them fishing the author object to use it to relate posts-->
-    <!--Also, time / tag info is already defined on each page-->
-    <!--Recommend criteria: tag -> category -> author -> time-->
 </div>
 <hr class="divider" />
 <div class="text-center title post-want-more">
     want more? here are some related posts:
 
-<div class="text-center title post-recommendations">
+<div class="text-center title post-recommendations post-recommend-container">
     {% assign iterations = 4 %} <!--Iterations may change if a recommendation is skipped due to being the same-->
     {% for post in site.posts %}
-        {% if post.title == page.title %} <!--Skip the current page-->
+        {% if post.title == page.title %} <!--Skip the current page so its not recommended-->
             {% assign iterations = iterations | plus: 1 %}
             {% continue %}
         {% endif %}
@@ -85,12 +82,12 @@ layout: default
             {% break %}
         {% endif %}
         
-        <div>
-            <a class="tla-link" href="{{post.url}}">{{post.title}}</a> posted on {{ post.date | date: "%b %-d, %Y" }}
-            
+        <div class="post-recommend-card">
+            <div class="post-recommend-info">{{post.author}} on {{ post.date | date: "%b %-d, %Y" }}</div>
+            <a class="tla-link" href="{{post.url}}">{{post.title}}</a>
         </div>
     {% endfor %}
-    <hr class="divider" />
-    or <a class="tla-link" href="{{site.baseurl}}/blog">binge read the whole blog here</a>
+    
 </div>
+or <a class="tla-link" href="{{site.baseurl}}/blog">binge read the whole blog here</a>
 </div> 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -84,7 +84,7 @@ layout: default
         
         <div class="post-recommend-card">
             <div class="post-recommend-info">{{post.author}} on {{ post.date | date: "%b %-d, %Y" }}</div>
-            <a class="tla-link" href="{{post.url}}">{{post.title}}</a>
+            <div><a class="tla-link" href="{{post.url}}">{{post.title}}</a></div>
         </div>
     {% endfor %}
     

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -65,8 +65,17 @@ layout: default
         {% endcapture %}
         {% include blog-author-card.html name=author_name role=author_role img=author_img url=author_url %}
     {% endfor %}
+
+    <!--Idea: piggyback off of them finsing the author object to use it to relate posts-->
+    <!--Also, time / tag info is already defined on each page-->
+    <!--Recommend criteria: tag -> category -> author -> time-->
 </div>
 <hr class="divider" />
 <p class="text-center title post-get-more">
-    want more? <a class="tla-link" href="{{site.baseurl}}/blog">binge read some more posts here</a>
+    want more? here are some related posts: 
+    {% for post in site.posts %}
+        <a href="{{post.url}}">{{post.title}}</a>
+    {% endfor %}
+    <a class="tla-link" href="{{site.baseurl}}/blog"> or binge read the whole blog here</a>
+
 </p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -66,7 +66,7 @@ layout: default
         {% include blog-author-card.html name=author_name role=author_role img=author_img url=author_url %}
     {% endfor %}
 
-    <!--Idea: piggyback off of them finsing the author object to use it to relate posts-->
+    <!--Idea: piggyback off of them fishing the author object to use it to relate posts-->
     <!--Also, time / tag info is already defined on each page-->
     <!--Recommend criteria: tag -> category -> author -> time-->
 </div>
@@ -75,15 +75,20 @@ layout: default
     want more? here are some related posts:
 
 <div class="text-center title post-recommendations">
+    {% assign iterations = 4 %} <!--Iterations may change if a recommendation is skipped due to being the same-->
     {% for post in site.posts %}
-    {% if forloop.index == 4 %} <!--Because Liquid thinks its MatLab and starts iterating at 1 smh-->
-        {% break %}
-    {% endif %}
-    <div>
-        <a class="tla-link" href="{{post.url}}">{{post.title}}</a>
-    </div>
+        {% if post.title == page.title %} <!--Skip the current page-->
+            {% assign iterations = iterations | plus: 1 %}
+            {% continue %}
+        {% endif %}
+        {% if forloop.index >= iterations %} <!--Because Liquid thinks its MatLab and starts iterating at 1 smh-->
+            {% break %}
+        {% endif %}
+        <div>
+            <a class="tla-link" href="{{post.url}}">{{post.title}}</a>
+        </div>
     {% endfor %}
     <hr class="divider" />
-    <a class="tla-link" href="{{site.baseurl}}/blog"> or binge read the whole blog here</a>
+    or <a class="tla-link" href="{{site.baseurl}}/blog">binge read the whole blog here</a>
 </div>
 </div> 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -84,8 +84,10 @@ layout: default
         {% if forloop.index >= iterations %} <!--Because Liquid thinks its MatLab and starts iterating at 1 smh-->
             {% break %}
         {% endif %}
+        
         <div>
-            <a class="tla-link" href="{{post.url}}">{{post.title}}</a>
+            <a class="tla-link" href="{{post.url}}">{{post.title}}</a> posted on {{ post.date | date: "%b %-d, %Y" }}
+            
         </div>
     {% endfor %}
     <hr class="divider" />

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -71,11 +71,19 @@ layout: default
     <!--Recommend criteria: tag -> category -> author -> time-->
 </div>
 <hr class="divider" />
-<p class="text-center title post-get-more">
-    want more? here are some related posts: 
-    {% for post in site.posts %}
-        <a href="{{post.url}}">{{post.title}}</a>
-    {% endfor %}
-    <a class="tla-link" href="{{site.baseurl}}/blog"> or binge read the whole blog here</a>
+<div class="text-center title post-want-more">
+    want more? here are some related posts:
 
-</p>
+<div class="text-center title post-recommendations">
+    {% for post in site.posts %}
+    {% if forloop.index == 4 %} <!--Because Liquid thinks its MatLab and starts iterating at 1 smh-->
+        {% break %}
+    {% endif %}
+    <div>
+        <a class="tla-link" href="{{post.url}}">{{post.title}}</a>
+    </div>
+    {% endfor %}
+    <hr class="divider" />
+    <a class="tla-link" href="{{site.baseurl}}/blog"> or binge read the whole blog here</a>
+</div>
+</div> 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -83,8 +83,8 @@ layout: default
         {% endif %}
         
         <div class="post-recommend-card">
-            <div class="post-recommend-info">{{post.author}} on {{ post.date | date: "%b %-d, %Y" }}</div>
             <div><a class="tla-link" href="{{post.url}}">{{post.title}}</a></div>
+            <div class="post-recommend-info">{{post.author}} on {{ post.date | date: "%b %-d, %Y" }}</div>
         </div>
     {% endfor %}
     

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -38,6 +38,26 @@
     font-size: 1.25rem;
 }
 
+.post-recommend-container{
+    display: flex;
+    justify-content: center;
+}
+
+.post-recommend-card{
+    padding: 1.5em;
+    margin: 1em;
+    margin-left: 0.25em;
+    margin-right: 0.25em;
+    border: 2px solid $teachla-green;
+    border-radius: 10px;
+    flex: auto;
+}
+
+.post-recommend-info{
+    margin-top: 0.25em;
+    font-size: 0.9rem;
+}
+
 .post-blockquote {
     background: #f9f9f9;
     border-left: 10px solid $teachla-green;

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -48,9 +48,7 @@
 }
 
 .post-recommend-card{
-    display: flex;
-    flex-direction: column;
-    padding: 1.5em;
+    padding: 1em;
     margin: 1em;
     margin-left: 0.25em;
     margin-right: 0.25em;
@@ -59,14 +57,8 @@
 
 }
 
-.post-recommend-title{
-    flex-basis: 10em;
-    flex: 3;
-}
-
 .post-recommend-info{
-    margin: auto;
-    margin-top: 0.25em;
+    margin: 1em;
     font-size: 0.9rem;
     
 }

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -29,9 +29,13 @@
     padding-left: 2em;
 }
 
-.post-get-more {
+.post-want-more {
     font-size: 1.5rem;
     margin-bottom: 2em;
+}
+
+.post-recommendations{
+    font-size: 1.25rem;
 }
 
 .post-blockquote {

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -31,7 +31,7 @@
 
 .post-want-more {
     font-size: 1.5rem;
-    margin-bottom: 2em;
+    margin: 2em;
 }
 
 .post-recommendations{
@@ -39,23 +39,36 @@
 }
 
 .post-recommend-container{
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
     justify-content: center;
+    margin-top: 1.5em;
+    padding-top: auto;
+    padding-bottom: auto;
 }
 
 .post-recommend-card{
+    display: flex;
+    flex-direction: column;
     padding: 1.5em;
     margin: 1em;
     margin-left: 0.25em;
     margin-right: 0.25em;
     border: 2px solid $teachla-green;
     border-radius: 10px;
-    flex: auto;
+
+}
+
+.post-recommend-title{
+    flex-basis: 10em;
+    flex: 3;
 }
 
 .post-recommend-info{
+    margin: auto;
     margin-top: 0.25em;
     font-size: 0.9rem;
+    
 }
 
 .post-blockquote {


### PR DESCRIPTION
This adds cards at the bottom of each post which contains recommended articles. Currently, the recommendations are only based on which posts are most recent, but more parameters can be added later. Each card contains the author(s), posting date, and title/link, and it shows three cards per page.