### PR TITLE
update auto width to 100 percent

### DIFF
--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -255,14 +255,14 @@ ul > li {
     text-decoration: none;
     background-position: left bottom;
     background-image: linear-gradient($off-color 0%, $link-effect-color 0%);
-    background-size: auto 15%;
+    background-size: 100% 15%;
     background-repeat: no-repeat;
 
     @media (min-width: $desktop-width) {
         transition: background 500ms ease;
 
         &:hover{
-            background-size: auto 85%;
+            background-size: 100% 85%;
             color: $effect-text-color;
         }
     }


### PR DESCRIPTION
I did introduce the bug; could potentially close #146 based on preliminary testing (mobile doesn't seem to support auto sizing for background well, tested on iPad with a static page)