### PR TITLE
added gem 'webrick' to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,5 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
+# Adding webrick since jekyll requires it
+gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     tzinfo-data (1.2020.2)
       tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     yell (2.2.2)
 
 PLATFORMS
@@ -108,6 +109,7 @@ DEPENDENCIES
   jekyll-seo-tag
   rake
   tzinfo-data
+  webrick
 
 BUNDLED WITH
-   2.1.4
+   2.2.5


### PR DESCRIPTION
It could be due to `ruby 3.0.0`. I don't remember having this problem a week or so ago and `jekyll` was bumped in December, so it might just be ruby on my computer. I don't know if this will break things for folks who haven't updated to 3.0.0. Please investigate