### PR TITLE
Change Ruby CI Action to test for Ruby 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7.2]
+        ruby: [2.7.2, 3.0.0]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Moves our CI action from `2.6.2` to `3.0.0`.