### PR TITLE
Refactor the team collection, post.authors, and related implementations

### DIFF
--- a/_docs/static-setup.md
+++ b/_docs/static-setup.md
@@ -27,8 +27,7 @@ The contents of the file are important. To start, we add what is called **head m
 
 ```md
 ---
-firstname: "Joe"
-lastname: "Bruin"
+name: "Joe Bruin"
 group: "member"
 ---
 ```
@@ -45,8 +44,7 @@ Here's an example team page for Josie Bruin:
 
 ```md
 ---
-firstname: Josie
-lastname: Bruin
+name: Josie  Bruin
 pronouns: "they/them"
 group: alum+
 graduating_year: 1923

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -55,10 +55,10 @@ Enjoyed the read? Share on social media! <br/>
 <hr class="divider" />
 <h2 class="title" id="authors">Author{% if page.authors.size > 1 %}s{% endif %}</h2>
     <div class="post-author-grid">
-        {% for authorobj in page.authors %}
-            {% assign author = site.team | where_exp:"item", "item.firstname == authorobj.fname and item.lastname == authorobj.lname" | first %}
+        {% for authorname in page.authors %}
+            {% assign author = site.team | where_exp:"item", "item.name == authorname" | first %}
             {% capture author_name %}
-                {{authorobj.fname}} {{authorobj.lname}}
+                {{author.name}}
             {% endcapture %}
             {% capture author_url %}
                 {{author.url}}

--- a/_layouts/team-member.html
+++ b/_layouts/team-member.html
@@ -6,14 +6,14 @@ layout: default
     <div class="row team-row">
         <div class="col">
             {% if page.img %}
-            <img class="profile-img" src="{{ site.baseurl }}/img/team/{{ page.img }}" alt="picture of {{ page.firstname }} {{ page.lastname }}">
+            <img class="profile-img" src="{{ site.baseurl }}/img/team/{{ page.img }}" alt="picture of {{ page.name }}">
             {% else %}
-            <img class="profile-img" src="{{site.baseurl}}/img/blank-profile.jpg" alt="picture of {{ page.firstname }} {{ page.lastname }}"/>
+            <img class="profile-img" src="{{site.baseurl}}/img/blank-profile.jpg" alt="picture of {{ page.name }}"/>
             {% endif %}
         </div>
 
         <div class="col">
-            <h1 class="title">{{ page.firstname }} {{ page.lastname }}
+            <h1 class="title">{{ page.name }}
                 <!-- only outputs pronouns if a person has pronouns listed-->
                 {% if page.pronouns %}
                     <span class="pronouns">({{page.pronouns}})</span>
@@ -51,17 +51,16 @@ layout: default
 
     <!-- blog posts -->
     <div class="team-posts">
-    {% assign has-title = false %}
-
-    {% for post in site.posts %}
-        {% for author in post.authors %}
-        {% if author.fname == page.firstname and author.lname == page.lastname %}
-
-        {% unless has-title %}
-        <h2 class="title"> Blog posts that {{ page.firstname }} has written: </h2>
-        {% assign has-title = true %}
-        {% endunless %}
-
+    {% assign authors_posts = site.posts | where_exp:"post", "post.authors contains page.name" | sort_by:"date" %}
+    {% if authors_posts.size > 0 %}
+        {% assign firstname = page.name | split: " " | first %}
+        {% if page.pronouns and page.pronouns contains "they" %}
+            {% assign have_has = "have" %}
+        {% else %}
+            {% assign have_has = "has" %}
+        {% endif %}
+        <h2 class="title"> Blog posts that {{ firstname }} {{ have_has }} written: </h2>
+        {% for post in authors_posts %}
             <section class="post-card">
 
                 <!-- TODO: IMPLEMENT TAGS! -->
@@ -82,9 +81,8 @@ layout: default
                 </div>
                 </div>
             </section>
-        {% endif %}
         {% endfor %}
-    {% endfor %}
+    {% endif %}
     </div>
     <!-- blog posts -->
 </div>

--- a/_layouts/team-member.html
+++ b/_layouts/team-member.html
@@ -55,12 +55,7 @@ layout: default
     {% assign authors_posts = site.posts | where_exp:"post", "post.authors contains page.name" | sort_by:"date" %}
     {% if authors_posts.size > 0 %}
         {% assign firstname = page.name | split: " " | first %}
-        {% if page.pronouns and page.pronouns contains "they" %}
-            {% assign have_has = "have" %}
-        {% else %}
-            {% assign have_has = "has" %}
-        {% endif %}
-        <h2 class="title"> Blog posts that {{ firstname }} {{ have_has }} written: </h2>
+        <h2 class="title"> Blog posts that {{ firstname }} has written: </h2>
         {% for post in authors_posts %}
             <section class="post-card">
 

--- a/_layouts/team-member.html
+++ b/_layouts/team-member.html
@@ -48,9 +48,10 @@ layout: default
             {% endif %}
         </div>
     </div>
+</div>
 
-    <!-- blog posts -->
-    <div class="team-posts">
+<!-- blog posts -->
+<div class="team-posts">
     {% assign authors_posts = site.posts | where_exp:"post", "post.authors contains page.name" | sort_by:"date" %}
     {% if authors_posts.size > 0 %}
         {% assign firstname = page.name | split: " " | first %}
@@ -83,9 +84,8 @@ layout: default
             </section>
         {% endfor %}
     {% endif %}
-    </div>
-    <!-- blog posts -->
 </div>
+<!-- blog posts -->
 
 <div class="cta-container">
     <hr class="divider">

--- a/_posts/2020-09-18-welcome-to-the-blog.md
+++ b/_posts/2020-09-18-welcome-to-the-blog.md
@@ -3,10 +3,8 @@ layout: post
 title: Welcome to Our Blog!
 author: Matt and Leo # this is just what's used for SEO
 authors:
-    - fname: Matthew
-      lname: Wang
-    - fname: Leo
-      lname: Krashanoff
+    - Matthew Wang
+    - Leo Krashanoff
 category: dev
 tags:
     - website

--- a/_posts/2020-09-19-how-we-made-getting-mean-about-error.md
+++ b/_posts/2020-09-19-how-we-made-getting-mean-about-error.md
@@ -3,10 +3,8 @@ layout: post
 title: How We Made "Getting Mean About Error"
 author: Miles and Michelle # this is just what's used for SEO
 authors:
-    - fname: Miles
-      lname: Kang
-    - fname: Michelle
-      lname: Zhuang
+    - Miles Kang
+    - Michelle Zhuang
 category: dev
 tags:
     - learning labs

--- a/_posts/2020-09-22-the-making-of-passworks.md
+++ b/_posts/2020-09-22-the-making-of-passworks.md
@@ -4,8 +4,7 @@ title: The Making of "Passworks"
 date: 2020-09-23 04:00:00 UTC
 author: Jamie
 authors:
-    - fname: Jamie
-      lname: Liu
+    - Jamie Liu
 category: dev
 tags:
     - learning labs

--- a/_posts/2020-10-13-ingredients-of-cipher-salad.md
+++ b/_posts/2020-10-13-ingredients-of-cipher-salad.md
@@ -4,14 +4,10 @@ title: Ingredients of "Cipher Salad"
 date: 2020-10-13 04:00:00 UTC
 author: Rachel, Leo, Janis, and Lisha
 authors:
-    - fname: Rachel
-      lname: Li
-    - fname: Leo
-      lname: Krashanoff
-    - fname: Janis
-      lname: Chen
-    - fname: Lisha
-      lname: Mohan
+    - Rachel Li
+    - Leo Krashanoff
+    - Janis Chen
+    - Lisha Mohan
 category: dev
 tags:
     - learning labs

--- a/_posts/2020-12-16-internship-retrospective.md
+++ b/_posts/2020-12-16-internship-retrospective.md
@@ -4,10 +4,8 @@ title: Teach LA’s Intern Search Experience
 date: 2020-12-16 04:00:00 UTC
 author: Bonnie and Sophie
 authors:
-    - fname: Bonnie
-      lname: Lee
-    - fname: Sophie
-      lname: Schoenmeyer
+    - Bonnie Lee
+    - Sophie Schoenmeyer
 category: internship
 tags:
     - internal

--- a/_posts/2021-01-04-new_year_new_blog.md
+++ b/_posts/2021-01-04-new_year_new_blog.md
@@ -4,12 +4,9 @@ title: New Year, New Blog
 date: 2021-01-04 04:00:00 UTC
 author: Trevor, Shounak, and Getty V
 authors:
-    - fname: Trevor
-      lname: Ong
-    - fname: Shounak
-      lname: Kuiry
-    - fname: Getty
-      lname: George V
+    - Trevor Ong
+    - Shounak Kuiry
+    - Getty George V
 category: dev
 tags:
     - blog

--- a/_posts/2021-1-4-introducing-our-new-curriculum pages.md
+++ b/_posts/2021-1-4-introducing-our-new-curriculum pages.md
@@ -4,14 +4,10 @@ title: Introducing Our New Curriculum Pages!
 date: 2021-01-03 17:00:00 PST
 author: Einar, Jun, Alex, and Prateek
 authors:
-    - fname: Einar
-      lname: Balan
-    - fname: Jun
-      lname: Ma
-    - fname: Alex
-      lname: Pun
-    - fname: Prateek
-      lname: Sane
+    - Einar Balan
+    - Jun Ma
+    - Alex Pun
+    - Prateek Sane
 category: dev
 tags:
     - curriculum

--- a/_sass/_team.scss
+++ b/_sass/_team.scss
@@ -58,6 +58,10 @@
     }
 }
 
+.team-posts {
+    margin-top: 3em;
+}
+
 .grid-col{
     @media(max-width: $desktop-width){
         .team-member-content{

--- a/_team/README.md
+++ b/_team/README.md
@@ -4,8 +4,7 @@ All our wonderful team profiles are stored here, and are used to track your past
 
 ```md
 ---
-firstname: "My First Name"
-lastname: "My Last Name"
+name: "My First Name + My Last Name"
 group: "member"
 title: "My Position Title"
 pronouns: "your preferred pronouns (if you're comfortable sharing)"
@@ -32,8 +31,7 @@ text **to be bold**, *italicized*, or make lists:
 
 | Field Key | Value | Required? |
 |-|-|-|
-| `firstname` | Your preferred first name! | ✅ |
-| `lastname` | Your last name! | ✅ |
+| `name` | Your name! (first + last)| ✅ |
 | `group` | Exactly one of the following: "member" (standard) \| "board" (serving the **current** board) \| "alum" (graduated) \| "alum+" (graduated in club, a.k.a. one of our "Graduated Greats") | ✅ |
 | `title` | What you do in club | ✅ |
 | `graduating_year` | What year you plan to graduate in. If you graduate as a Teach LA member, you will be added to our list of "Graduating Greats!" | ✅ |
@@ -57,8 +55,7 @@ A proliferating pedagogy professional. Just getting started, they have added an 
 
 ```md
 ---
-firstname: Joe
-lastname: Bruin
+name: Joe Bruin
 group: member
 title: Instructor
 graduating_year: 1923
@@ -77,8 +74,7 @@ The fully-evolved Teach LA member: served on multiple boards, is a "Graduating G
 
 ```md
 ---
-firstname: Josie
-lastname: Bruin
+name: Josie Bruin
 group: alum+
 graduating_year: 1923
 

--- a/_team/acervantes.md
+++ b/_team/acervantes.md
@@ -1,6 +1,5 @@
 ---
-firstname: Alejandra
-lastname: Cervantes
+name: Alejandra Cervantes
 group: alum
 graduating_year: 2019
 

--- a/_team/aduong.md
+++ b/_team/aduong.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Alvin"
-lastname: "Duong"
+name: "Alvin Duong"
 title: "Instructor"
 group: "member"
 inactive: true

--- a/_team/agautier.md
+++ b/_team/agautier.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Andrew"
-lastname: "Gautier"
+name: "Andrew Gautier"
 title: "Graphic Designer"
 group: "member"
 img: "agautier.jpg"

--- a/_team/aghodsian.md
+++ b/_team/aghodsian.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Ashley"
-lastname: "Ghodsian"
+name: "Ashley Ghodsian"
 title: "Advisor (JEDI)"
 secondary: "Python Instructor, Translator"
 group: "board"

--- a/_team/amanoberoi.md
+++ b/_team/amanoberoi.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Aman"
-lastname: "Oberoi"
+name: "Aman Oberoi"
 title: "AI Outreach Officer"
 group: "member"
 graduating_year: 2024

--- a/_team/anguyen.md
+++ b/_team/anguyen.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Alvin"
-lastname: "Nguyen"
+name: "Alvin Nguyen"
 title: "Developer"
 group: "member"
 img: "anguyen.jpg"

--- a/_team/anguyen2.md
+++ b/_team/anguyen2.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Austin"
-lastname: "Nguyen"
+name: "Austin Nguyen"
 group: "member"
 title: "Python Curriculum Developer"
 secondary: "Translator"

--- a/_team/apanse.md
+++ b/_team/apanse.md
@@ -1,6 +1,5 @@
 ---
-firstname: Apurva
-lastname: Panse
+name: Apurva Panse
 group: alum+
 graduating_year: 2018
 

--- a/_team/apun.md
+++ b/_team/apun.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Alex"
-lastname: "Pun"
+name: "Alex Pun"
 group: "member"
 title: "Developer"
 graduating_year: 2023

--- a/_team/asane.md
+++ b/_team/asane.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Aseem"
-lastname: "Sane"
+name: "Aseem Sane"
 title: "Developer"
 group: "member"
 img: "asane.jpg"

--- a/_team/asubramonian.md
+++ b/_team/asubramonian.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Arjun"
-lastname: "Subramonian"
+name: "Arjun Subramonian"
 title: "Advisor (JEDI)"
 secondary: "AI/ML Lead"
 group: "board"

--- a/_team/atong.md
+++ b/_team/atong.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Anna"
-lastname: "Tong"
+name: "Anna Tong"
 group: "member"
 title: "Developer"
 graduating_year: "2024"

--- a/_team/aung.md
+++ b/_team/aung.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Amanda"
-lastname: "Ung"
+name: "Amanda Ung"
 group: "member"
 graduating_year: 2023
 github: "a17ung"

--- a/_team/awang.md
+++ b/_team/awang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Alyssa"
-lastname: "Wang"
+name: "Alyssa Wang"
 title: "Cyber Lead"
 secondary: "Developer"
 group: "member"

--- a/_team/azhang.md
+++ b/_team/azhang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Allison"
-lastname: "Zhang"
+name: "Allison Zhang"
 title: "Developer"
 group: "member"
 graduating_year: 2023

--- a/_team/blee.md
+++ b/_team/blee.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Bonnie"
-lastname: "Lee"
+name: "Bonnie Lee"
 title: "Advisor (ACM)"
 group: "board"
 img: blee.jpg

--- a/_team/bluo.md
+++ b/_team/bluo.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Bryan"
-lastname: "Luo"
+name: "Bryan Luo"
 title: "Developer & Instructor"
 group: "member"
 img: "bluo.jpg"

--- a/_team/cborden.md
+++ b/_team/cborden.md
@@ -1,6 +1,5 @@
 ---
-firstname: Connor
-lastname: Borden
+name: Connor Borden
 group: alum+
 graduating_year: 2019
 

--- a/_team/cdaly.md
+++ b/_team/cdaly.md
@@ -1,6 +1,5 @@
 ---
-firstname: Connor
-lastname: Daly
+name: Connor Daly
 group: member
 title: developer
 graduating_year: 2023

--- a/_team/cindudhara.md
+++ b/_team/cindudhara.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Christina"
-lastname: "Indudhara"
+name: "Christina Indudhara"
 group: "alum+"
 graduating_year: 2020
 

--- a/_team/ckapler.md
+++ b/_team/ckapler.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Chase"
-lastname: "Kapler"
+name: "Chase Kapler"
 title: "React Native Lead"
 email: "chasekap@gmail.com"
 group: "board"

--- a/_team/ckim.md
+++ b/_team/ckim.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Charlene"
-lastname: "Kim"
+name: "Charlene Kim"
 group: "member"
 title: "Developer"
 pronouns: "she/her"

--- a/_team/claw.md
+++ b/_team/claw.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Celebi"
-lastname: "Law"
+name: "Celebi Law"
 group: "member"
 title: "Emerson Instructor"
 graduating_year: 2024

--- a/_team/cuy.md
+++ b/_team/cuy.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Chloe"
-lastname: "Uy"
+name: "Chloe Uy"
 title: "Outreach Director"
 secondary: "Emerson Lead"
 group: "board"

--- a/_team/cyachanin.md
+++ b/_team/cyachanin.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Chloe"
-lastname: "Yachanin"
+name: "Chloe Yachanin"
 title: "Instructor"
 group: "member"
 inactive: true

--- a/_team/darrenzhang.md
+++ b/_team/darrenzhang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Darren"
-lastname: "Zhang"
+name: "Darren Zhang"
 title: "Developer"
 group: "member"
 graduating_year: 2024

--- a/_team/dolson.md
+++ b/_team/dolson.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Dominic"
-lastname: "Olson"
+name: "Dominic Olson"
 group: "member"
 title: "Emerson Instructor"
 secondary: "Curriculum Developer"

--- a/_team/ebalan.md
+++ b/_team/ebalan.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Einar"
-lastname: "Balan"
+name: "Einar Balan"
 group: "member"
 graduating_year: 2024
 img: ebalan.png

--- a/_team/esegura.md
+++ b/_team/esegura.md
@@ -1,6 +1,5 @@
 ---
-firstname: Enrique
-lastname: Segura
+name: Enrique Segura
 group: alum+
 graduating_year: 2017
 

--- a/_team/eto.md
+++ b/_team/eto.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Ethan"
-lastname: "To"
+name: "Ethan To"
 group: "member"
 title: "Developer"
 img: "eto.jpg"

--- a/_team/ewen.md
+++ b/_team/ewen.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Edmond"
-lastname: "Wen"
+name: "Edmond Wen"
 group: "member"
 title: "Developer"
 secondary: "Emerson Instructor"

--- a/_team/eyu.md
+++ b/_team/eyu.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Eden"
-lastname: "Yu"
+name: "Eden Yu"
 group: "member"
 title: "Scratch Curriculum Developer"
 pronouns: "she/her"

--- a/_team/ezhong.md
+++ b/_team/ezhong.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Evan"
-lastname: "Zhong"
+name: "Evan Zhong"
 title: "Developer"
 secondary: "Instructor"
 group: "member"

--- a/_team/ftech.md
+++ b/_team/ftech.md
@@ -1,6 +1,5 @@
 ---
-firstname: Furn
-lastname: Techalertumpai
+name: Furn Techalertumpai
 graduating_year: 2020
 group: alum
 

--- a/_team/ggeorge.md
+++ b/_team/ggeorge.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Getty"
-lastname: "George V"
+name: "Getty George V"
 title: "Developer"
 group: "member"
 img: "ggeorge.jpg"

--- a/_team/hco.md
+++ b/_team/hco.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Hanna"
-lastname: "Co"
+name: "Hanna Co"
 title: "Developer"
 group: "member"
 img: "hco.jpg"

--- a/_team/hwoo.md
+++ b/_team/hwoo.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Helia"
-lastname: "Woo"
+name: "Helia Woo"
 title: "Advisor (JEDI)"
 secondary: "Python Video Lead"
 img: "hwoo.jpg"

--- a/_team/ishah.md
+++ b/_team/ishah.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Isha"
-lastname: "Shah"
+name: "Isha Shah"
 group: "member"
 title: "Emerson Instructor"
 pronouns: "she/her"

--- a/_team/jcarlson.md
+++ b/_team/jcarlson.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Jonathan"
-lastname: "Carlson"
+name: "Jonathan Carlson"
 title: "Developer"
 group: "member"
 img: "jcarlson.jpg"

--- a/_team/jchen.md
+++ b/_team/jchen.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Janis"
-lastname: "Chen"
+name: "Janis Chen"
 title: "Developer"
 secondary: "Instructor"
 group: "member"

--- a/_team/jglickstein.md
+++ b/_team/jglickstein.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Jonah"
-lastname: "Glickstein"
+name: "Jonah Glickstein"
 title: "Scratch Curriculum Developer"
 group: "member"
 graduating_year: 2024

--- a/_team/jiinkim.md
+++ b/_team/jiinkim.md
@@ -1,6 +1,5 @@
 ---
-firstname: Jiin
-lastname: Kim
+name: Jiin Kim
 group: member
 title: Developer
 graduating_year: 2024

--- a/_team/jjewik.md
+++ b/_team/jjewik.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Jason"
-lastname: "Jewik"
+name: "Jason Jewik"
 title: "AI Outreach Officer"
 group: "member"
 ---

--- a/_team/jliu.md
+++ b/_team/jliu.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Jamie"
-lastname: "Liu"
+name: "Jamie Liu"
 title: "Lead Developer"
 group: "member"
 img: "jliu.jpg"

--- a/_team/jma.md
+++ b/_team/jma.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Jun"
-lastname: "Ma"
+name: "Jun Ma"
 group: "member"
 graduating_year: 2022
 title: "Developer"

--- a/_team/jofferman.md
+++ b/_team/jofferman.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Julia"
-lastname: "Offerman"
+name: "Julia Offerman"
 title: "Instructor"
 group: "member"
 inactive: true

--- a/_team/jsi.md
+++ b/_team/jsi.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Joshua"
-lastname: "Si"
+name: "Joshua Si"
 title: "Developer"
 group: "member"
 img: "jsi.jpg"

--- a/_team/jstucky.md
+++ b/_team/jstucky.md
@@ -1,6 +1,5 @@
 ---
-firstname: John
-lastname: Stucky
+name: John Stucky
 group: alum+
 graduating_year: 2019
 

--- a/_team/jtsai.md
+++ b/_team/jtsai.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Janice"
-lastname: "Tsai"
+name: "Janice Tsai"
 title: "Developer"
 group: "member"
 img: "jtsai.jpg"

--- a/_team/kaitota.md
+++ b/_team/kaitota.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Kai"
-lastname: "Tota"
+name: "Kai Tota"
 title: "AI Outreach Officer"
 group: "member"
 graduating_year: 2024

--- a/_team/kbabu.md
+++ b/_team/kbabu.md
@@ -1,6 +1,5 @@
 ---
-firstname: Krishna
-lastname: Babu
+name: Krishna Babu
 group: alum+
 graduating_year: 2018
 

--- a/_team/klevy.md
+++ b/_team/klevy.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Kara"
-lastname: "Levy"
+name: "Kara Levy"
 title: "BEAM Liaison"
 secondary: "Instructor"
 group: "member"

--- a/_team/knamuduri.md
+++ b/_team/knamuduri.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Keertana"
-lastname: "Namuduri"
+name: "Keertana Namuduri"
 title: "Special Events Director"
 group: "board"
 img: knamuduri.jpeg

--- a/_team/krashanoff.md
+++ b/_team/krashanoff.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Leo"
-lastname: "Krashanoff"
+name: "Leo Krashanoff"
 title: "Dev Team Director"
 group: "board"
 img: "krash.jpg"

--- a/_team/kwang.md
+++ b/_team/kwang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Kaitlyn"
-lastname: "Wang"
+name: "Kaitlyn Wang"
 title: "Special Events Director"
 group: "board"
 img: "kwang.jpg"

--- a/_team/ldalton.md
+++ b/_team/ldalton.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Luke"
-lastname: "Dalton"
+name: "Luke Dalton"
 title: "Developer"
 group: "member"
 img: "ldalton.jpg"

--- a/_team/llee.md
+++ b/_team/llee.md
@@ -1,6 +1,5 @@
 ---
-firstname: Lawrence
-lastname: Lee
+name: Lawrence Lee
 graduating_year: 2020
 group: alum+
 ---

--- a/_team/lmohan.md
+++ b/_team/lmohan.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Lisha"
-lastname: "Mohan"
+name: "Lisha Mohan"
 title: "Lead Developer"
 secondary: "Instructor"
 group: "member"

--- a/_team/lnemeh.md
+++ b/_team/lnemeh.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Lauren"
-lastname: "Nemeh"
+name: "Lauren Nemeh"
 group: "member"
 title: "Emerson Instructor"
 pronouns: "she/her"

--- a/_team/lxu.md
+++ b/_team/lxu.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Lydia"
-lastname: "Xu"
+name: "Lydia Xu"
 group: "member"
 title: "Developer"
 img: "lxu.jpg"

--- a/_team/matruiz.md
+++ b/_team/matruiz.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Mat"
-lastname: "Ruiz"
+name: "Mat Ruiz"
 title: "AI Outreach Officer"
 group: "member"
 graduating_year: 2024

--- a/_team/mattf.md
+++ b/_team/mattf.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Matt"
-lastname: "Fan"
+name: "Matt Fan"
 title: "Developer"
 group: "member"
 img: "mattf.png"

--- a/_team/mattwang.md
+++ b/_team/mattwang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Matthew"
-lastname: "Wang"
+name: "Matthew Wang"
 title: "President"
 group: "board"
 img: "mwang.jpg"

--- a/_team/mayaraman.md
+++ b/_team/mayaraman.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Maya"
-lastname: "Raman"
+name: "Maya Raman"
 title: "AI Outreach Officer"
 group: "member"
 graduating_year: 2024

--- a/_team/mgrieve.md
+++ b/_team/mgrieve.md
@@ -1,6 +1,5 @@
 ---
-firstname: Michael
-lastname: Grieve
+name: Michael Grieve
 group: alum+
 graduating_year: 2019
 

--- a/_team/mhmimy.md
+++ b/_team/mhmimy.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Malak"
-lastname: "Hmimy"
+name: "Malak Hmimy"
 title: "Sepulveda School Lead"
 group: "board"
 img: mhmimy.jpg

--- a/_team/michaelwang.md
+++ b/_team/michaelwang.md
@@ -1,6 +1,5 @@
 ---
-firstname: Michael
-lastname: Wang
+name: Michael Wang
 graduating_year: 2018
 group: alum
 

--- a/_team/michellz.md
+++ b/_team/michellz.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Michelle"
-lastname: "Zhuang"
+name: "Michelle Zhuang"
 title: "Developer"
 group: "member"
 img: "michellz.jpg"

--- a/_team/mkang.md
+++ b/_team/mkang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Miles"
-lastname: "Kang"
+name: "Miles Kang"
 title: "Developer"
 group: "member"
 img: "miles.jpg"

--- a/_team/mkearney.md
+++ b/_team/mkearney.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Milo"
-lastname: "Kearney"
+name: "Milo Kearney"
 title: "Scratch Curriculum Developer"
 group: "member"
 pronouns: "he/him"

--- a/_team/mli.md
+++ b/_team/mli.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Maggie"
-lastname: "Li"
+name: "Maggie Li"
 pronouns: "she/her"
 group: "member"
 title: Developer

--- a/_team/mnieva.md
+++ b/_team/mnieva.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Matthew"
-lastname: "Nieva"
+name: "Matthew Nieva"
 title: "Developer"
 group: "member"
 img: "mnieva.jpeg"

--- a/_team/myoshida.md
+++ b/_team/myoshida.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Matthew"
-lastname: "Yoshida"
+name: "Matthew Yoshida"
 group: "member"
 title: Developer
 img: myoshida.jpeg

--- a/_team/nendow.md
+++ b/_team/nendow.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Nathan"
-lastname: "Endow"
+name: "Nathan Endow"
 group: "member"
 title: "Developer"
 graduating_year: 2024

--- a/_team/nishamcnealis.md
+++ b/_team/nishamcnealis.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Nisha"
-lastname: "McNealis"
+name: "Nisha McNealis"
 title: "AI Outreach Officer"
 group: "member"
 graduating_year: 2024

--- a/_team/njeong.md
+++ b/_team/njeong.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Nicolas"
-lastname: "Jeong"
+name: "Nicolas Jeong"
 title: "Developer"
 pronouns: "he/him"
 group: "member"

--- a/_team/nkumar.md
+++ b/_team/nkumar.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Nikhil"
-lastname: "Kumar"
+name: "Nikhil Kumar"
 title: "Curriculum Director"
 secondary: "Python Lead"
 group: "board"

--- a/_team/nlu.md
+++ b/_team/nlu.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Nina"
-lastname: "Lu"
+name: "Nina Lu"
 title: "Special Events Director"
 group: "board"
 img: nlu.jpg

--- a/_team/nvan.md
+++ b/_team/nvan.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Nhi"
-lastname: "Van"
+name: "Nhi Van"
 title: "Developer Liaison"
 group: "member"
 img: "nvan.jpg"

--- a/_team/oobrien.md
+++ b/_team/oobrien.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Oscar"
-lastname: "O'Brien"
+name: "Oscar O'Brien"
 group: "member"
 title: "Python Curriculum Developer"
 pronouns: "he/him"

--- a/_team/pflanders.md
+++ b/_team/pflanders.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Peter"
-lastname: "Flanders"
+name: "Peter Flanders"
 title: "Instructor"
 group: "member"
 img: "pflanders.jpeg"

--- a/_team/psane.md
+++ b/_team/psane.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Prateek"
-lastname: "Sane"
+name: "Prateek Sane"
 group: "member"
 graduating_year: 2024
 title: "Developer"

--- a/_team/pvenkatesh.md
+++ b/_team/pvenkatesh.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Pragathi"
-lastname: "Venkatesh"
+name: "Pragathi Venkatesh"
 title: "Advisor"
 group: "member"
 img: pragathi.jpg

--- a/_team/rli.md
+++ b/_team/rli.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Rachel"
-lastname: "Li"
+name: "Rachel Li"
 title: "Developer"
 secondary: "Instructor"
 group: "member"

--- a/_team/rtran.md
+++ b/_team/rtran.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Robert"
-lastname: "Tran"
+name: "Robert Tran"
 group: "member"
 title: "Emerson Instructor"
 pronouns: "he/him"

--- a/_team/rwang.md
+++ b/_team/rwang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Regina"
-lastname: "Wang"
+name: "Regina Wang"
 title: "Special Events Director"
 secondary: "Developer"
 group: "board"

--- a/_team/rwen.md
+++ b/_team/rwen.md
@@ -1,6 +1,5 @@
 ---
-firstname: Richard
-lastname: Wen
+name: Richard Wen
 group: alum+
 graduating_year: 2019
 

--- a/_team/scho.md
+++ b/_team/scho.md
@@ -1,6 +1,5 @@
 ---
-firstname: Shane
-lastname: Cho
+name: Shane Cho
 graduating_year: 2021
 
 positions:

--- a/_team/sjha.md
+++ b/_team/sjha.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Sharvani"
-lastname: "Jha"
+name: "Sharvani Jha"
 title: "Advisor (Moonshots)"
 group: "board"
 img: sharvani.png

--- a/_team/skelman.md
+++ b/_team/skelman.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Stephen"
-lastname: "Kelman"
+name: "Stephen Kelman"
 group: "member"
 title: "Emerson Instructor"
 pronouns: "he/him"

--- a/_team/skuiry.md
+++ b/_team/skuiry.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Shounak"
-lastname: "Kuiry"
+name: "Shounak Kuiry"
 title: "Developer"
 group: "member"
 graduating_year: "2024"

--- a/_team/spark.md
+++ b/_team/spark.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Seongbin"
-lastname: "Park"
+name: "Seongbin Park"
 group: "member"
 title: "Video Producer"
 secondary: "Instructor"

--- a/_team/sschoenmeyer.md
+++ b/_team/sschoenmeyer.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Sophie"
-lastname: "Schoenmeyer"
+name: "Sophie Schoenmeyer"
 title: "Logistics Director"
 group: "board"
 img: "sschoenmeyer.jpg"

--- a/_team/ssharfuddin.md
+++ b/_team/ssharfuddin.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Saba"
-lastname: "Sharfuddin"
+name: "Saba Sharfuddin"
 group: "member"
 title: "Emerson Instructor"
 pronouns: "she/her"

--- a/_team/swei.md
+++ b/_team/swei.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Stephanie"
-lastname: "Wei"
+name: "Stephanie Wei"
 title: "Developer"
 group: "member"
 img: "swei.jpg"

--- a/_team/tomokif.md
+++ b/_team/tomokif.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Tomoki"
-lastname: "T. Fukazawa"
+name: "Tomoki T. Fukazawa"
 title: "Developer"
 group: "member"
 img: "tomokif.jpg"

--- a/_team/tong.md
+++ b/_team/tong.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Trevor"
-lastname: "Ong"
+name: "Trevor Ong"
 title: "Developer"
 group: "member"
 graduating_year: 2024

--- a/_team/tpoon.md
+++ b/_team/tpoon.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Timothy"
-lastname: "Poon"
+name: "Timothy Poon"
 title: "Developer"
 group: "member"
 img: "tpoon.jpg"

--- a/_team/vhunter.md
+++ b/_team/vhunter.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Varsha"
-lastname: "Hunter"
+name: "Varsha Hunter"
 group: "member"
 title: "Developer"
 graduating_year: "2022"

--- a/_team/whuang.md
+++ b/_team/whuang.md
@@ -1,6 +1,5 @@
 ---
-firstname: "William"
-lastname: "Huang"
+name: "William Huang"
 group: "member"
 title: "Python Instructor"
 pronouns: "he/him"

--- a/_team/wobrian.md
+++ b/_team/wobrian.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Will"
-lastname: "O'Brien"
+name: "Will O'Brien"
 title: "Lead Developer"
 group: "member"
 img: "willob.jpg"

--- a/_team/zxue.md
+++ b/_team/zxue.md
@@ -1,6 +1,5 @@
 ---
-firstname: "Zihan"
-lastname: "Xue"
+name: "Zihan Xue"
 group: "member"
 title: "Developer"
 graduating_year: 2024

--- a/team.html
+++ b/team.html
@@ -14,13 +14,13 @@ permalink: "/team"
 </p>
 
 {% assign president = site.team | where_exp:"person", "person.group contains 'board' and person.title == 'President'" | group_by:"title" %}
-{% assign board = site.team | where_exp:"item", "item.group contains 'board' and item.title != 'President'" | sort:"lastname" | group_by:"title" | sort:"name" %}
+{% assign board = site.team | where_exp:"item", "item.group contains 'board' and item.title != 'President'" | sort:"name" | group_by:"title" | sort:"name" %}
 {% assign leadership = president | concat: board %}
 
-{% assign members = site.team | where_exp:"item", "item.group == 'member'" | sort:"lastname" %}
+{% assign members = site.team | where_exp:"item", "item.group == 'member'" | sort:"name" %}
 
-{% assign boards = site.team | where_exp:"item", "item.positions" | sort:"lastname" %}
-{% assign alumsplus = site.team | where_exp:"item", "item.group == 'alum+'" | sort:"lastname" | group_by:"graduating_year" | sort:"name" %}
+{% assign boards = site.team | where_exp:"item", "item.positions" | sort:"name" %}
+{% assign alumsplus = site.team | where_exp:"item", "item.group == 'alum+'" | sort:"name" | group_by:"graduating_year" | sort:"name" %}
 
 <div class="team-member-grid board-member-grid">
     {% for group in leadership %}

--- a/team.html
+++ b/team.html
@@ -29,9 +29,9 @@ permalink: "/team"
         <div class="grid-col">
             <div class="profile-img-container">
                 {% if member.img %}
-                        <img class="profile-img" src="{{ site.baseurl }}/img/team/{{ member.img }}" alt="picture of {{ member.firstname }} {{ member.lastname }}"/>
+                        <img class="profile-img" src="{{ site.baseurl }}/img/team/{{ member.img }}" alt="picture of {{ member.name }}"/>
                 {% else %}
-                    <img class="profile-img" src="{{site.baseurl}}/img/blank-profile.jpg" alt="temporary picture for {{ member.firstname }} {{ member.lastname }}"/>
+                    <img class="profile-img" src="{{site.baseurl}}/img/blank-profile.jpg" alt="temporary picture for {{ member.name }}"/>
                 {% endif %}
                 </a>
             </div>
@@ -40,7 +40,7 @@ permalink: "/team"
         <div class="grid-col">
             <div class="team-member-content">
                 <h3 class="no-margin title">
-                    {{ member.firstname }} {{ member.lastname }}
+                    {{ member.name }}
                     {% if member.pronouns %}
                         <span class = "pronouns"> ({{member.pronouns}})</span>
                     {% endif %}
@@ -91,9 +91,9 @@ permalink: "/team"
         <div class="grid-col">
             <div class="profile-img-container">
                 {% if member.img %}
-                    <img class="profile-img" src="{{ site.baseurl }}/img/team/{{ member.img }}" alt="picture of {{ member.firstname }} {{ member.lastname }}"/>
+                    <img class="profile-img" src="{{ site.baseurl }}/img/team/{{ member.img }}" alt="picture of {{ member.name }}"/>
                     {% else %}
-                    <img class="profile-img" src="{{site.baseurl}}/img/blank-profile.jpg" alt="temporary picture for {{ member.firstname }} {{ member.lastname }}"/>
+                    <img class="profile-img" src="{{site.baseurl}}/img/blank-profile.jpg" alt="temporary picture for {{ member.name }}"/>
                 {% endif %}
                 </a>
             </div>
@@ -102,7 +102,7 @@ permalink: "/team"
         <div class="grid-col">
             <div class="team-member-content">
                 <h3 class="no-margin title">
-                    {{ member.firstname }} {{ member.lastname }}
+                    {{ member.name }}
                     {% if member.pronouns %}
                         <span class = "pronouns"> ({{member.pronouns}})</span>
                     {% endif %}
@@ -157,7 +157,7 @@ permalink: "/team"
 {% for member in boards %}
     {% for position in member.positions %}
         {% if position.year == boardYear %}
-        <li><b>{{ member.firstname }} {{ member.lastname }}</b> ({{ member.graduating_year }}): {{ position.title }}</li>
+        <li><b>{{ member.name }}</b> ({{ member.graduating_year }}): {{ position.title }}</li>
         {% endif %}
     {% endfor %}
 {% endfor %}
@@ -170,7 +170,7 @@ permalink: "/team"
 <ul>
 {% for year in alumsplus %}
 {% for member in year.items %}
-    <li><b>{{ member.firstname }} {{ member.lastname }}</b> ({{ member.graduating_year }})</li>
+    <li><b>{{ member.name }}</b> ({{ member.graduating_year }})</li>
 {% endfor %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
### Closes #242
- Combined `firstname` and `lastname` fields of the `team` collection, preserved the original style of quotation marks of each team member's `.md` file.
- Combined `fname` and `lname` in `post.authors`.
- Updated related files to be compatible with changes: `team.html`, `team-member.html`, `post.html`.
- Updated `README.md` for the `team` collection

### Changes unrelated to #242
- Thanks to the refactor, `team-member.html` now uses a cleaner way to create an iterable of all blog posts of a member.
- Team member pages now displays "Blog posts that MEMBER have/has written: " depending on the pronouns.
- Change the div structure in `team-member.html` so that blog posts become a separate <div> `team-posts`, instead of being inside of the <div> `team-profile`

### Known Problem

- [x]  `team.html` used to sort members using the `lastname` field when creating iterables. Now without the `lastname` field, members aren't properly sorted.

### Potential Problems

- [x] The statements checking for pronouns could be flawed / not clean enough.
- [x] Although I checked through files to find those that might be impacted by this refactoring, there might be files that I missed. **e.g.** I updated the README for `team`, but I didn't find a README for `post`, which has also been refactored.
- [x] In team member pages, the whitespace above and below the line "Blog posts that MEMBER have/has written:" seems a bit unbalanced.