### PR TITLE
Fixes Sticky Footer Issue

### DIFF
--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -6,12 +6,15 @@
     box-sizing: border-box;
     padding: 0;
     margin: 0;
+    min-height: 100%;
  }
  body {
     margin: 0;
     padding: 0;
     padding-top: 70px;
     min-height: calc(100vh - 70px);
+    //unclicking this element will either fix it or not, depends on the page
+    height: 100%;
     min-width: 100%;
     font-family: $font-body;
     color: $font-primary-color;

--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -6,15 +6,13 @@
     box-sizing: border-box;
     padding: 0;
     margin: 0;
-    min-height: 100%;
+    min-height:100vh;
  }
  body {
     margin: 0;
     padding: 0;
     padding-top: 70px;
-    min-height: calc(100vh - 70px);
-    //unclicking this element will either fix it or not, depends on the page
-    height: 100%;
+    min-height: 100vh;
     min-width: 100%;
     font-family: $font-body;
     color: $font-primary-color;


### PR DESCRIPTION
There was an issue on multiple pages where the footer was not sticking to the bottom. To the html tag in _basics.scss, I added min-height: 100%. Now the footer should stick to the bottom, even when zoomed out.

Closes #225.